### PR TITLE
refresh game account information after game exit

### DIFF
--- a/src/Starward/Pages/LauncherPage.xaml.cs
+++ b/src/Starward/Pages/LauncherPage.xaml.cs
@@ -404,6 +404,11 @@ public sealed partial class LauncherPage : Page
                 processTimer?.Start();
             }
         }
+        else
+        {
+            _logger.LogInformation("Game process exited");
+            DispatcherQueue.TryEnqueue(GetGameAccount);
+        }
     }
 
 


### PR DESCRIPTION
#290 

* 在游戏中登录账号一
* 在 Starward 中编辑完账号一信息后点击保存
* 在游戏中登录账号二，**此时要切换到其他游戏标签页再回来，才会刷新账号信息**
* 在 Starward 中编辑完账号二信息后点击保存

在游戏退出后直接刷新账号信息，可以直接解决此类疑问。

新说明如下👇

* 在游戏中登录账号一
* 在 Starward 中编辑完账号一信息（必须要填写昵称）后点击保存
* 在游戏中登出账号一，登录账号二，关闭游戏
* 在 Starward 中编辑完账号二信息（必须要填写昵称）后点击保存