### PR TITLE
Use ReadOnlySpan to make the alloction free

### DIFF
--- a/src/Starward.Core/Gacha/GachaLogClient.cs
+++ b/src/Starward.Core/Gacha/GachaLogClient.cs
@@ -19,14 +19,11 @@ public abstract class GachaLogClient
     protected const string WEB_CACHE_PATH_YS_CN = @"YuanShen_Data\webCaches\Cache\Cache_Data\data_2";
     protected const string WEB_CACHE_PATH_YS_OS = @"GenshinImpact_Data\webCaches\Cache\Cache_Data\data_2";
 
-    protected const string WEB_PREFIX_YS_CN = "https://webstatic.mihoyo.com/hk4e/event/e20190909gacha-v2/index.html";
-    protected const string WEB_PREFIX_YS_OS = "https://webstatic-sea.hoyoverse.com/genshin/event/e20190909gacha-v2/index.html";
-
     protected const string API_PREFIX_YS_CN = "https://hk4e-api.mihoyo.com/event/gacha_info/api/getGachaLog";
     protected const string API_PREFIX_YS_OS = "https://hk4e-api-os.hoyoverse.com/event/gacha_info/api/getGachaLog";
 
-    protected static readonly ReadOnlyMemory<byte> MEMORY_WEB_PREFIX_YS_CN = new(Encoding.UTF8.GetBytes(WEB_PREFIX_YS_CN));
-    protected static readonly ReadOnlyMemory<byte> MEMORY_WEB_PREFIX_YS_OS = new(Encoding.UTF8.GetBytes(WEB_PREFIX_YS_OS));
+    protected static ReadOnlySpan<byte> MEMORY_WEB_PREFIX_YS_CN => "https://webstatic.mihoyo.com/hk4e/event/e20190909gacha-v2/index.html"u8;
+    protected static ReadOnlySpan<byte> MEMORY_WEB_PREFIX_YS_OS => "https://webstatic-sea.hoyoverse.com/genshin/event/e20190909gacha-v2/index.html"u8;
 
 
 
@@ -35,14 +32,11 @@ public abstract class GachaLogClient
 
     protected const string WEB_CACHE_SR_PATH = @"StarRail_Data\webCaches\Cache\Cache_Data\data_2";
 
-    protected const string WEB_PREFIX_SR_CN = "https://webstatic.mihoyo.com/hkrpg/event/e20211215gacha-v2/index.html";
-    protected const string WEB_PREFIX_SR_OS = "https://gs.hoyoverse.com/hkrpg/event/e20211215gacha-v2/index.html";
-
     protected const string API_PREFIX_SR_CN = "https://api-takumi.mihoyo.com/common/gacha_record/api/getGachaLog";
     protected const string API_PREFIX_SR_OS = "https://api-os-takumi.mihoyo.com/common/gacha_record/api/getGachaLog";
 
-    protected static readonly ReadOnlyMemory<byte> MEMORY_WEB_PREFIX_SR_CN = new(Encoding.UTF8.GetBytes(WEB_PREFIX_SR_CN));
-    protected static readonly ReadOnlyMemory<byte> MEMORY_WEB_PREFIX_SR_OS = new(Encoding.UTF8.GetBytes(WEB_PREFIX_SR_OS));
+    protected static ReadOnlySpan<byte> MEMORY_WEB_PREFIX_SR_CN => "https://webstatic.mihoyo.com/hkrpg/event/e20211215gacha-v2/index.html"u8;
+    protected static ReadOnlySpan<byte> MEMORY_WEB_PREFIX_SR_OS => "https://gs.hoyoverse.com/hkrpg/event/e20211215gacha-v2/index.html"u8;
 
 
 
@@ -187,7 +181,7 @@ public abstract class GachaLogClient
 
 
 
-    private static ReadOnlyMemory<byte> GetGachaUrlPattern(GameBiz gameBiz)
+    private static ReadOnlySpan<byte> GetGachaUrlPattern(GameBiz gameBiz)
     {
         return gameBiz switch
         {
@@ -321,21 +315,19 @@ public abstract class GachaLogClient
     }
 
 
-    protected static string? FindMatchStringFromFile(string path, params ReadOnlyMemory<byte>[] prefixes)
+    protected static string? FindMatchStringFromFile(string path, ReadOnlySpan<byte> prefix)
     {
         using var fs = File.Open(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite | FileShare.Delete);
         var ms = new MemoryStream();
         fs.CopyTo(ms);
         var span = ms.ToArray().AsSpan();
-        foreach (var prefix in prefixes)
+        var index = span.LastIndexOf(prefix);
+        if (index >= 0)
         {
-            var index = span.LastIndexOf(prefix.Span);
-            if (index >= 0)
-            {
-                var length = span[index..].IndexOfAny("\0\""u8);
-                return Encoding.UTF8.GetString(span.Slice(index, length));
-            }
+            var length = span[index..].IndexOfAny("\0\""u8);
+            return Encoding.UTF8.GetString(span.Slice(index, length));
         }
+
         return null;
     }
 

--- a/src/Starward.Core/Gacha/GachaLogClient.cs
+++ b/src/Starward.Core/Gacha/GachaLogClient.cs
@@ -22,8 +22,8 @@ public abstract class GachaLogClient
     protected const string API_PREFIX_YS_CN = "https://hk4e-api.mihoyo.com/event/gacha_info/api/getGachaLog";
     protected const string API_PREFIX_YS_OS = "https://hk4e-api-os.hoyoverse.com/event/gacha_info/api/getGachaLog";
 
-    protected static ReadOnlySpan<byte> MEMORY_WEB_PREFIX_YS_CN => "https://webstatic.mihoyo.com/hk4e/event/e20190909gacha-v2/index.html"u8;
-    protected static ReadOnlySpan<byte> MEMORY_WEB_PREFIX_YS_OS => "https://webstatic-sea.hoyoverse.com/genshin/event/e20190909gacha-v2/index.html"u8;
+    protected static ReadOnlySpan<byte> SPAN_WEB_PREFIX_YS_CN => "https://webstatic.mihoyo.com/hk4e/event/e20190909gacha-v2/index.html"u8;
+    protected static ReadOnlySpan<byte> SPAN_WEB_PREFIX_YS_OS => "https://webstatic-sea.hoyoverse.com/genshin/event/e20190909gacha-v2/index.html"u8;
 
 
 
@@ -35,8 +35,8 @@ public abstract class GachaLogClient
     protected const string API_PREFIX_SR_CN = "https://api-takumi.mihoyo.com/common/gacha_record/api/getGachaLog";
     protected const string API_PREFIX_SR_OS = "https://api-os-takumi.mihoyo.com/common/gacha_record/api/getGachaLog";
 
-    protected static ReadOnlySpan<byte> MEMORY_WEB_PREFIX_SR_CN => "https://webstatic.mihoyo.com/hkrpg/event/e20211215gacha-v2/index.html"u8;
-    protected static ReadOnlySpan<byte> MEMORY_WEB_PREFIX_SR_OS => "https://gs.hoyoverse.com/hkrpg/event/e20211215gacha-v2/index.html"u8;
+    protected static ReadOnlySpan<byte> SPAN_WEB_PREFIX_SR_CN => "https://webstatic.mihoyo.com/hkrpg/event/e20211215gacha-v2/index.html"u8;
+    protected static ReadOnlySpan<byte> SPAN_WEB_PREFIX_SR_OS => "https://gs.hoyoverse.com/hkrpg/event/e20211215gacha-v2/index.html"u8;
 
 
 
@@ -185,10 +185,10 @@ public abstract class GachaLogClient
     {
         return gameBiz switch
         {
-            GameBiz.hk4e_cn or GameBiz.hk4e_cloud => MEMORY_WEB_PREFIX_YS_CN,
-            GameBiz.hk4e_global => MEMORY_WEB_PREFIX_YS_OS,
-            GameBiz.hkrpg_cn => MEMORY_WEB_PREFIX_SR_CN,
-            GameBiz.hkrpg_global => MEMORY_WEB_PREFIX_SR_OS,
+            GameBiz.hk4e_cn or GameBiz.hk4e_cloud => SPAN_WEB_PREFIX_YS_CN,
+            GameBiz.hk4e_global => SPAN_WEB_PREFIX_YS_OS,
+            GameBiz.hkrpg_cn => SPAN_WEB_PREFIX_SR_CN,
+            GameBiz.hkrpg_global => SPAN_WEB_PREFIX_SR_OS,
             _ => throw new ArgumentOutOfRangeException($"Unknown region {gameBiz}"),
         };
     }


### PR DESCRIPTION
Compiler will automatically rewrite const data ref to the bytes in data section of the assembly.
So it's allocation free, zero overhead.

See sample code:
https://sharplab.io/#v2:EYLgZgpghgLgrgJwgZwLQGED2AbbEDGMAlpgHYAyRMECU2yAPgMSly5TB4AEAJkchzwBYAFAABAEwBGUWIDMXDshi1CXSV3RcA3qK76uABwREAbrAjqpANi4AlaDwDypbAE8AyoaikAPMDdqAD4uACEuAF4QgCJqZWi4AA4AblEAXyA=

