### PR TITLE
opt: Switch Client

### DIFF
--- a/src/Starward.Language/Lang.Designer.cs
+++ b/src/Starward.Language/Lang.Designer.cs
@@ -3488,6 +3488,15 @@ namespace Starward.Language {
         }
         
         /// <summary>
+        ///   查找类似 File verification failed, need to download resources. Click on Confirm to download. 的本地化字符串。
+        /// </summary>
+        public static string SwitchClientPage_FileVerificationFailedNeedToDownloadResources {
+            get {
+                return ResourceManager.GetString("SwitchClientPage_FileVerificationFailedNeedToDownloadResources", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   查找类似 File verification failed, please try again. 的本地化字符串。
         /// </summary>
         public static string SwitchClientPage_FileVerificationFailedPleaseTryAgain {
@@ -3529,6 +3538,15 @@ namespace Starward.Language {
         public static string SwitchClientPage_StartSwitching {
             get {
                 return ResourceManager.GetString("SwitchClientPage_StartSwitching", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   查找类似 Switching 的本地化字符串。
+        /// </summary>
+        public static string SwitchClientPage_Switching {
+            get {
+                return ResourceManager.GetString("SwitchClientPage_Switching", resourceCulture);
             }
         }
         

--- a/src/Starward.Language/Lang.resx
+++ b/src/Starward.Language/Lang.resx
@@ -1410,4 +1410,10 @@ Do you accept the risk and continue to use it?</value>
   <data name="UpdateContentWindow_RecentlyUpdatedContent" xml:space="preserve">
     <value>Recently Updated Content</value>
   </data>
+  <data name="SwitchClientPage_FileVerificationFailedNeedToDownloadResources" xml:space="preserve">
+    <value>File verification failed, need to download resources. Click on Confirm to download.</value>
+  </data>
+  <data name="SwitchClientPage_Switching" xml:space="preserve">
+    <value>Switching</value>
+  </data>
 </root>

--- a/src/Starward.Language/Lang.zh-CN.resx
+++ b/src/Starward.Language/Lang.zh-CN.resx
@@ -1410,4 +1410,10 @@
   <data name="UpdateContentWindow_RecentlyUpdatedContent" xml:space="preserve">
     <value>最近更新内容</value>
   </data>
+  <data name="SwitchClientPage_FileVerificationFailedNeedToDownloadResources" xml:space="preserve">
+    <value>文件校验失败，需要下载资源。点击确认以下载。</value>
+  </data>
+  <data name="SwitchClientPage_Switching" xml:space="preserve">
+    <value>切换中</value>
+  </data>
 </root>

--- a/src/Starward/Pages/LauncherPage.xaml
+++ b/src/Starward/Pages/LauncherPage.xaml
@@ -400,6 +400,7 @@
                             VerticalAlignment="Stretch"
                             BorderThickness="0"
                             Command="{x:Bind SwitchClientCommand}"
+                            CommandParameter="true"
                             FontSize="14"
                             Style="{ThemeResource AccentButtonStyle}"
                             Visibility="{x:Bind IsSwitchClientButtonEnable}">

--- a/src/Starward/Pages/LauncherPage.xaml.cs
+++ b/src/Starward/Pages/LauncherPage.xaml.cs
@@ -1325,7 +1325,7 @@ public sealed partial class LauncherPage : PageBase
 
 
     [RelayCommand]
-    private void SwitchClient()
+    private void SwitchClient(string autorun = "false")
     {
         if (IsUpdateGameButtonEnable)
         {
@@ -1337,10 +1337,10 @@ public sealed partial class LauncherPage : PageBase
         }
         else
         {
-            MainWindow.Current.OverlayFrameNavigateTo(typeof(SwitchClientPage), CurrentGameBiz);
+            MainWindow.Current.OverlayFrameNavigateTo(typeof(SwitchClientPage), new Tuple<GameBiz,bool>(CurrentGameBiz, autorun == "true"));
         }
     }
-
+    
 
 
     [RelayCommand]

--- a/src/Starward/Pages/SwitchClientPage.xaml
+++ b/src/Starward/Pages/SwitchClientPage.xaml
@@ -93,7 +93,8 @@
                         Command="{x:Bind StartSwitchClientCommand}"
                         Content="{x:Bind lang:Lang.SwitchClientPage_StartSwitching}"
                         IsEnabled="{x:Bind IsPrepared}"
-                        Style="{ThemeResource AccentButtonStyle}" />
+                        Style="{ThemeResource AccentButtonStyle}"
+                        Visibility="{x:Bind Autorun, Converter={StaticResource BoolToVisibilityReversedConverter}}" />
                 <Button MinWidth="100"
                         HorizontalAlignment="Right"
                         VerticalAlignment="Center"

--- a/src/Starward/Pages/SwitchClientPage.xaml.cs
+++ b/src/Starward/Pages/SwitchClientPage.xaml.cs
@@ -709,7 +709,7 @@ public sealed partial class SwitchClientPage : PageBase
                 FileName = "PowerShell",
                 Arguments = sb.ToString(),
                 UseShellExecute = true,
-                CreateNoWindow = true,
+                WindowStyle = ProcessWindowStyle.Hidden,
                 Verb = "runas",
             });
             if (p != null)


### PR DESCRIPTION
close #845 
如果从主界面右下角按钮进入切换客户端页，隐藏下方“开始切换”按钮，单击确认即依次进行：

- 准备切换工作（但不包括下载资源）
- 切换客户端
- 关闭切换客户端页

如果准备工作时发现资源未下载则需再次确认下载资源（进入原始流程）。

现在流程感觉有点不应该的麻烦，基于硬链接的方案还得等挺久吧（