### PR TITLE
genshin: Migrate to new global API Endpoint

### DIFF
--- a/src/Starward.Core/Gacha/GachaLogClient.cs
+++ b/src/Starward.Core/Gacha/GachaLogClient.cs
@@ -20,7 +20,7 @@ public abstract class GachaLogClient
     protected const string WEB_CACHE_PATH_YS_OS = @"GenshinImpact_Data\webCaches\Cache\Cache_Data\data_2";
 
     protected const string API_PREFIX_YS_CN = "https://public-operation-hk4e.mihoyo.com/gacha_info/api/getGachaLog";
-    protected const string API_PREFIX_YS_OS = "https://hk4e-api-os.hoyoverse.com/gacha_info/api/getGachaLog";
+    protected const string API_PREFIX_YS_OS = "https://public-operation-hk4e-sg.hoyoverse.com/gacha_info/api/getGachaLog";
 
     protected static ReadOnlySpan<byte> SPAN_WEB_PREFIX_YS_CN => "https://webstatic.mihoyo.com/hk4e/event/e20190909gacha-v3/index.html"u8;
     protected static ReadOnlySpan<byte> SPAN_WEB_PREFIX_YS_OS => "https://gs.hoyoverse.com/genshin/event/e20190909gacha-v3/index.html"u8;

--- a/src/Starward.Core/SelfQuery/SelfQueryClient.cs
+++ b/src/Starward.Core/SelfQuery/SelfQueryClient.cs
@@ -79,7 +79,7 @@ public class SelfQueryClient
             }
             if (url.StartsWith("https://cs.hoyoverse.com/csc-service-center-fe/index.html"))
             {
-                prefixUrl = "https://hk4e-api-os.hoyoverse.com";
+                prefixUrl = "https://public-operation-hk4e-sg.hoyoverse.com";
             }
             if (string.IsNullOrWhiteSpace(prefixUrl))
             {

--- a/src/Starward.Core/SelfQuery/SelfQueryClient.cs
+++ b/src/Starward.Core/SelfQuery/SelfQueryClient.cs
@@ -77,7 +77,8 @@ public class SelfQueryClient
             {
                 prefixUrl = "https://hk4e-api.mihoyo.com";
             }
-            if (url.StartsWith("https://cs.hoyoverse.com/csc-service-center-fe/index.html"))
+            if (url.StartsWith("https://cs.hoyoverse.com/csc-service-center-fe/index.html") 
+                || url.StartsWith("https://cs.hoyoverse.com/static/hoyoverse-new-csc-service-hall-fe/index.html"))
             {
                 prefixUrl = "https://public-operation-hk4e-sg.hoyoverse.com";
             }


### PR DESCRIPTION
The genshin gacha & Account Records API of global(Asia/EU/NA) seems to have been migrated to the similar sub-domain as the mihoyo ver.

fix: #987