### PR TITLE
fix: fixed the bug that method `CurrentTaskFinished` was executed multiple times by multiple threads 

### DIFF
--- a/src/Starward/Services/Download/InstallGameService.cs
+++ b/src/Starward/Services/Download/InstallGameService.cs
@@ -722,14 +722,14 @@ internal class InstallGameService
         async Task RunTasksAsync()
         {
             _cancellationTokenSource = new CancellationTokenSource();
-            var tsaks = new Task[Environment.ProcessorCount];
+            var tasts = new Task[Environment.ProcessorCount];
             for (int i = 0; i < Environment.ProcessorCount; i++)
             {
-                tsaks[i] = ExecuteTaskItemAsync(_cancellationTokenSource.Token);
+                tasts[i] = ExecuteTaskItemAsync(_cancellationTokenSource.Token);
             }
             try
             {
-                await Task.WhenAll(tsaks).ConfigureAwait(false);
+                await Task.WhenAll(tasts).ConfigureAwait(false);
             }
             finally
             {

--- a/src/Starward/Services/Download/InstallGameService.cs
+++ b/src/Starward/Services/Download/InstallGameService.cs
@@ -627,7 +627,7 @@ internal class InstallGameService
 
     protected void StartTask(InstallGameState state)
     {
-        if (State != InstallGameState.None) return;
+        if (_concurrentExecuteThreadCount > 0) return;
 
         if (state is InstallGameState.Download)
         {

--- a/src/Starward/Services/Download/InstallGameService.cs
+++ b/src/Starward/Services/Download/InstallGameService.cs
@@ -722,14 +722,14 @@ internal class InstallGameService
         async Task RunTasksAsync()
         {
             _cancellationTokenSource = new CancellationTokenSource();
-            var tasts = new Task[Environment.ProcessorCount];
+            var tasks = new Task[Environment.ProcessorCount];
             for (int i = 0; i < Environment.ProcessorCount; i++)
             {
-                tasts[i] = ExecuteTaskItemAsync(_cancellationTokenSource.Token);
+                tasks[i] = ExecuteTaskItemAsync(_cancellationTokenSource.Token);
             }
             try
             {
-                await Task.WhenAll(tasts).ConfigureAwait(false);
+                await Task.WhenAll(tasks).ConfigureAwait(false);
             }
             finally
             {


### PR DESCRIPTION
修复了 #1082 和 #1083 提及的bug。

~~另外，照此方法修改后，`ConcurrentExecuteThreadCount`和`_concurrentExecuteThreadCount`本质上已经没有用处了，如果后续不需要知道当前正在运行的Tasks数量，可将其删除。~~（`StartTask`会反复执行，还是需要使用`ConcurrentExecuteThreadCount`判断上一个任务的线程是否已经完全退出）