### PR TITLE
fix: correct key to match SQL queries & update hsr china self query host

### DIFF
--- a/src/Starward.Core/SelfQuery/SelfQueryClient.cs
+++ b/src/Starward.Core/SelfQuery/SelfQueryClient.cs
@@ -89,11 +89,11 @@ public class SelfQueryClient
         }
         if (gameBiz.ToGame() == GameBiz.hkrpg)
         {
-            if (url.StartsWith("https://webstatic.mihoyo.com/csc-service-center-fe/index.html"))
+            if (url.StartsWith("https://webstatic.mihoyo.com/csc-service-center-fe/index.html") || url.StartsWith("https://webstatic.mihoyo.com/static/mihoyo-new-csc-service-hall-fe/index.html"))
             {
                 prefixUrl = "https://api-takumi.mihoyo.com";
             }
-            if (url.StartsWith("https://cs.hoyoverse.com/csc-service-center-fe/index.html"))
+            if (url.StartsWith("https://cs.hoyoverse.com/csc-service-center-fe/index.html") || url.StartsWith("https://cs.hoyoverse.com/static/hoyoverse-new-csc-service-hall-fe/index.html"))
             {
                 prefixUrl = "https://public-operation-hkrpg-sg.hoyoverse.com";
             }

--- a/src/Starward/Services/Gacha/GachaLogService.cs
+++ b/src/Starward/Services/Gacha/GachaLogService.cs
@@ -115,7 +115,7 @@ internal abstract class GachaLogService
     public virtual string? GetGachaLogUrlByUid(long uid)
     {
         using var dapper = _database.CreateConnection();
-        return dapper.QueryFirstOrDefault<string>("SELECT Url FROM GachaLogUrl WHERE Uid = @uid AND GameBiz = @GameBiz LIMIT 1;", new { uid, CurrentGameBiz });
+        return dapper.QueryFirstOrDefault<string>("SELECT Url FROM GachaLogUrl WHERE Uid = @uid AND GameBiz = @GameBiz LIMIT 1;", new { uid, GameBiz = CurrentGameBiz });
     }
 
 


### PR DESCRIPTION
- 修复复制抽卡连接时，GetGachaLogUrlByUid 方法中参数名称与 SQL 语句中的参数名称不一致（粗略看了一下没发现地方有类似问题）
- 更新《崩坏：星穹铁道》中国服自助查询API URL。（为什么官方给星铁更新API就更新了一半）