### PR TITLE
fix: Cannot resume after pausing download

### DIFF
--- a/src/Starward/Services/Download/InstallGameService.cs
+++ b/src/Starward/Services/Download/InstallGameService.cs
@@ -625,8 +625,8 @@ internal class InstallGameService
 
 
 
-    protected List<Task> _taskItems;
-    public List<Task> TaskItems => _taskItems;
+    protected Task[] _taskItems;
+    public Task[] TaskItems => _taskItems;
 
 
 
@@ -726,14 +726,14 @@ internal class InstallGameService
         async Task RunTasksAsync()
         {
             _cancellationTokenSource = new CancellationTokenSource();
-            var tasks = new Task[Environment.ProcessorCount];
+            _taskItems = new Task[Environment.ProcessorCount];
             for (int i = 0; i < Environment.ProcessorCount; i++)
             {
-                tasks[i] = ExecuteTaskItemAsync(_cancellationTokenSource.Token);
+                _taskItems[i] = ExecuteTaskItemAsync(_cancellationTokenSource.Token);
             }
             try
             {
-                await Task.WhenAll(tasks).ConfigureAwait(false);
+                await Task.WhenAll(_taskItems).ConfigureAwait(false);
             }
             finally
             {


### PR DESCRIPTION
修复在合并 #1019 时，[删除了](https://github.com/Scighost/Starward/pull/1019/commits/c9858163296cad35c8cfd8276c090f293f9e48d3)为_taskItems赋值的逻辑导致ArgumentNullException异常。
该逻辑用于实现“避免暂停下载后快速继续造成的文件被占用异常”。#1037 中包含更好的处理方案，如果近期有时间审查并合并其，参考 https://github.com/Scighost/Starward/issues/1096#issuecomment-2354582131 删除已有逻辑。