### PR TITLE
Fix bugs

### DIFF
--- a/src/Starward.Core/GameRecord/StarRail/DailyNote/StarRailDailyNote.cs
+++ b/src/Starward.Core/GameRecord/StarRail/DailyNote/StarRailDailyNote.cs
@@ -43,10 +43,16 @@ public class StarRailDailyNote
 
 
     /// <summary>
-    /// 明天开拓力回满
+    /// 隔天开拓力回满
     /// </summary>
     [JsonIgnore]
-    public bool StaminaTomorrowRecovery => StaminaFullTime.LocalDateTime.Date > CurrentTime.LocalDateTime.Date;
+    public bool StaminaRecoveryBeyondTomorrow => StaminaFullTime.LocalDateTime.Date > CurrentTime.LocalDateTime.Date;
+
+    /// <summary>
+    /// 开拓力回满剩余天数
+    /// </summary>
+    [JsonIgnore]
+    public string StaminaRecoveryDaysRemaining => (StaminaFullTime.LocalDateTime.Date - CurrentTime.LocalDateTime.Date).Days.ToString("+0");
 
     /// <summary>
     /// 已接取委托次数

--- a/src/Starward/Features/Gacha/GachaLogPage.xaml
+++ b/src/Starward/Features/Gacha/GachaLogPage.xaml
@@ -24,7 +24,7 @@
         </Grid.RowDefinitions>
 
 
-        <TextBlock Margin="20,0,0,0"
+        <TextBlock Margin="24,0,0,0"
                    HorizontalAlignment="Left"
                    VerticalAlignment="Center"
                    FontSize="20"

--- a/src/Starward/Features/Gacha/GachaStatsCard.xaml
+++ b/src/Starward/Features/Gacha/GachaStatsCard.xaml
@@ -211,7 +211,6 @@
                                            Text="{x:Bind Pity}"
                                            Visibility="{x:Bind IsPointerIn, Converter={StaticResource BoolToVisibilityConverter}}" />
                                 <TextBlock Grid.Column="1"
-                                           Canvas.ZIndex="1"
                                            HorizontalAlignment="Right"
                                            VerticalAlignment="Center"
                                            Margin="0,0,0,5"

--- a/src/Starward/Features/Gacha/GachaStatsCard.xaml
+++ b/src/Starward/Features/Gacha/GachaStatsCard.xaml
@@ -173,7 +173,6 @@
                                 <Grid.ColumnDefinitions>
                                     <ColumnDefinition Width="40" />
                                     <ColumnDefinition />
-                                    <ColumnDefinition Width="Auto" />
                                     <ColumnDefinition Width="Auto" MinWidth="20" />
                                 </Grid.ColumnDefinitions>
                                 <Border Grid.Column="1"
@@ -190,9 +189,10 @@
                                            Text="{x:Bind Name}"
                                            TextTrimming="CharacterEllipsis"
                                            Visibility="{x:Bind IsPointerIn, Converter={StaticResource BoolToVisibilityReversedConverter}}" />
-                                <TextBlock Grid.Column="3"
+                                <TextBlock Grid.Column="2"
                                            HorizontalAlignment="Right"
                                            VerticalAlignment="Center"
+                                           Margin="0,0,0,5"
                                            IsTextScaleFactorEnabled="False"
                                            Text="{x:Bind Pity}"
                                            Visibility="{x:Bind IsPointerIn, Converter={StaticResource BoolToVisibilityReversedConverter}}" />
@@ -202,16 +202,19 @@
                                            Text="{x:Bind Name}"
                                            TextTrimming="CharacterEllipsis"
                                            Visibility="{x:Bind IsPointerIn, Converter={StaticResource BoolToVisibilityConverter}}" />
-                                <TextBlock Grid.Column="3"
+                                <TextBlock Grid.Column="2"
                                            HorizontalAlignment="Right"
                                            VerticalAlignment="Center"
+                                           Margin="0,0,0,5"
                                            Foreground="{ThemeResource Rarity5ForegroundBrush}"
                                            IsTextScaleFactorEnabled="False"
                                            Text="{x:Bind Pity}"
                                            Visibility="{x:Bind IsPointerIn, Converter={StaticResource BoolToVisibilityConverter}}" />
-                                <TextBlock Grid.Column="2"
+                                <TextBlock Grid.Column="1"
+                                           Canvas.ZIndex="1"
                                            HorizontalAlignment="Right"
                                            VerticalAlignment="Center"
+                                           Margin="0,0,0,5"
                                            FontSize="12"
                                            FontStyle="Italic"
                                            Foreground="{ThemeResource Rarity5ForegroundBrush}"

--- a/src/Starward/Features/GameRecord/DailyNote/DailyNoteButton.xaml
+++ b/src/Starward/Features/GameRecord/DailyNote/DailyNoteButton.xaml
@@ -400,8 +400,8 @@
                                     <TextBlock VerticalAlignment="Top"
                                                FontSize="10"
                                                Foreground="{ThemeResource AccentTextFillColorPrimaryBrush}"
-                                               Text="+1"
-                                               Visibility="{x:Bind StarRailDailyNote.StaminaTomorrowRecovery}" />
+                                               Text="{x:Bind StarRailDailyNote.StaminaRecoveryDaysRemaining}"
+                                               Visibility="{x:Bind StarRailDailyNote.StaminaRecoveryBeyondTomorrow}" />
                                 </StackPanel>
                                 <TextBlock FontSize="12"
                                            Foreground="{ThemeResource SystemFillColorSuccessBrush}"

--- a/src/Starward/Features/GameRecord/GameRecordPage.xaml
+++ b/src/Starward/Features/GameRecord/GameRecordPage.xaml
@@ -27,7 +27,8 @@
             </NavigationView.Resources>
 
             <NavigationView.PaneCustomContent>
-                <Grid Height="56"
+                <Grid Margin="0,12,0,0"
+                      Height="56"
                       HorizontalAlignment="Stretch"
                       ColumnSpacing="8">
                     <Grid.ColumnDefinitions>

--- a/src/Starward/Features/GameSetting/GameSettingPage.xaml
+++ b/src/Starward/Features/GameSetting/GameSettingPage.xaml
@@ -16,7 +16,7 @@
         </Grid.RowDefinitions>
 
         <ScrollViewer>
-            <Grid Margin="24,24,0,24" ColumnSpacing="24">
+            <Grid Margin="24,20,0,24" ColumnSpacing="24">
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition />
                     <ColumnDefinition />

--- a/src/Starward/Features/Screenshot/ScreenshotPage.xaml
+++ b/src/Starward/Features/Screenshot/ScreenshotPage.xaml
@@ -34,7 +34,7 @@
         </animations:AnimationDictionary>
     </Page.Resources>
 
-    <Grid>
+    <Grid Margin="0,12,0,0">
         <Grid.RowDefinitions>
             <RowDefinition Height="44" />
             <RowDefinition />

--- a/src/Starward/Features/SelfQuery/SelfQueryPage.xaml
+++ b/src/Starward/Features/SelfQuery/SelfQueryPage.xaml
@@ -16,7 +16,7 @@
         <local:SelfQueryStatsNumberBrushConverter x:Key="SelfQueryStatsNumberBrushConverter" />
     </Page.Resources>
 
-    <Grid>
+    <Grid Margin="0,12,0,0">
         <Grid.RowDefinitions>
             <RowDefinition Height="44" />
             <RowDefinition Height="Auto" />

--- a/src/Starward/Features/Setting/SettingPage.xaml
+++ b/src/Starward/Features/Setting/SettingPage.xaml
@@ -29,7 +29,9 @@
             <NavigationView.PaneHeader>
                 <TextBlock Margin="16,12,0,8"
                            FontSize="20"
-                           Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                           HorizontalAlignment="Left"
+                           VerticalAlignment="Center"
+                           FontWeight="Bold"
                            Text="{x:Bind lang:Lang.SettingPage_AppSettings}" />
             </NavigationView.PaneHeader>
 


### PR DESCRIPTION
- 将抽卡记录物品“up!”标识的位置设成与进度条重叠，个人感觉进度条右侧因标志留余过多空不太美观，同时解决“已垫”和已出的物品进度条长度不等的问题
- 修了星铁便签开拓力恢复时间不显示+2的问题
- 微调一些页面的布局，使其更统一