### PR TITLE
restore tray launch feature

### DIFF
--- a/src/Starward/Features/GameLauncher/GameLauncherService.cs
+++ b/src/Starward/Features/GameLauncher/GameLauncherService.cs
@@ -6,10 +6,12 @@ using Starward.Features.HoYoPlay;
 using Starward.Features.PlayTime;
 using Starward.Helpers;
 using System;
+using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Text.Json;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 
@@ -490,5 +492,18 @@ internal partial class GameLauncherService
 
 
 
+    public static List<GameInfo> GetCachedGameInfos()
+    {
+        try
+        {
+            string? json = AppConfig.CachedGameInfo;
+            if (!string.IsNullOrWhiteSpace(json))
+            {
+                return JsonSerializer.Deserialize<List<GameInfo>>(json) ?? [];
+            }
+        }
+        catch { }
+        return [];
+    }
 
 }

--- a/src/Starward/Features/GameSelector/GameSelector.xaml.cs
+++ b/src/Starward/Features/GameSelector/GameSelector.xaml.cs
@@ -77,7 +77,7 @@ public sealed partial class GameSelector : UserControl
 
     public void InitializeGameSelector()
     {
-        List<GameInfo> gameInfos = GetCachedGameInfos();
+        List<GameInfo> gameInfos = GameLauncherService.GetCachedGameInfos();
         InitializeGameIconsArea(gameInfos);
         InitializeGameServerArea(gameInfos);
         InitializeInstalledGamesCommand.Execute(null);
@@ -116,22 +116,6 @@ public sealed partial class GameSelector : UserControl
         catch { }
     }
 
-
-
-
-    private List<GameInfo> GetCachedGameInfos()
-    {
-        try
-        {
-            string? json = AppConfig.CachedGameInfo;
-            if (!string.IsNullOrWhiteSpace(json))
-            {
-                return JsonSerializer.Deserialize<List<GameInfo>>(json) ?? [];
-            }
-        }
-        catch { }
-        return [];
-    }
 
 
 
@@ -840,6 +824,7 @@ public sealed partial class GameSelector : UserControl
                     return;
                 }
 
+                WeakReferenceMessenger.Default.Send(new InstalledGameRefreshedMessage());
                 InstalledGamesActualSize = $"{(totalSize - fileSize + actualSize) / GB:F2}GB";
                 InstalledGamesSavedSize = $"{(fileSize - actualSize) / GB:F2}GB";
             }
@@ -861,7 +846,7 @@ public sealed partial class GameSelector : UserControl
     {
         try
         {
-            List<GameInfo> gameInfos = GetCachedGameInfos();
+            List<GameInfo> gameInfos = GameLauncherService.GetCachedGameInfos();
             var sb = new StringBuilder();
             foreach (GameInfo item in gameInfos)
             {

--- a/src/Starward/Features/GameSelector/InstalledGameRefreshedMessage.cs
+++ b/src/Starward/Features/GameSelector/InstalledGameRefreshedMessage.cs
@@ -1,0 +1,6 @@
+﻿namespace Starward.Features.GameSelector;
+
+public class InstalledGameRefreshedMessage
+{
+
+}

--- a/src/Starward/Features/ViewHost/SystemTrayWindow.xaml
+++ b/src/Starward/Features/ViewHost/SystemTrayWindow.xaml
@@ -8,6 +8,8 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:sc="using:Starward.Controls"
              xmlns:sf="using:Starward.Frameworks"
+             xmlns:sfgg="using:Starward.Features.GameSelector"
+             xmlns:sh="using:Starward.Helpers"
              x:DefaultBindMode="OneWay"
              Closed="WindowEx_Closed"
              mc:Ignorable="d">
@@ -20,6 +22,58 @@
                         ToolTipText="Starward" />
 
         <StackPanel Padding="8">
+
+            <ItemsControl ItemsSource="{x:Bind InstalledGames}">
+                <ItemsControl.ItemTemplate>
+                    <DataTemplate x:DataType="sfgg:GameBizIcon">
+                        <Button Name="Button_StartGame"
+                            HorizontalAlignment="Stretch"
+                            HorizontalContentAlignment="Left"
+                            Style="{ThemeResource DateTimePickerFlyoutButtonStyle}"
+                            Click="Button_StartGame_Click"
+                            Tag="{Binding}">
+                            <Grid ColumnSpacing="10">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="Auto" />
+                                    <ColumnDefinition Width="Auto" />
+                                </Grid.ColumnDefinitions>
+                                <Grid Width="28"
+                                      Height="28"
+                                      sh:PointerCursor.CursorShape="Hand"
+                                      CornerRadius="8"
+                                      IsDoubleTapEnabled="True"
+                                      IsTapEnabled="True"
+                                      Shadow="{ThemeResource ThemeShadow}"
+                                      Translation="0,0,16">
+                                    <sc:CachedImage Width="28"
+                                            Height="28"
+                                            Source="{x:Bind GameIcon}" />
+                                    <Image Width="14"
+                                            Height="14"
+                                            HorizontalAlignment="Right"
+                                            VerticalAlignment="Bottom">
+                                        <Image.Source>
+                                            <BitmapImage DecodePixelHeight="14"
+                                                         DecodePixelType="Logical"
+                                                         DecodePixelWidth="14"
+                                                         UriSource="{x:Bind ServerIcon}" />
+                                        </Image.Source>
+                                    </Image>
+                                    <Border Background="#60000000" Opacity="{x:Bind MaskOpacity}">
+                                        <Border.OpacityTransition>
+                                            <ScalarTransition />
+                                        </Border.OpacityTransition>
+                                    </Border>
+                                </Grid>
+                                <TextBlock Grid.Column="1"
+                                           VerticalAlignment="Center"
+                                           Text="{x:Bind ServerName}"
+                                           TextTrimming="None" />
+                            </Grid>
+                        </Button>
+                    </DataTemplate>
+                </ItemsControl.ItemTemplate>
+            </ItemsControl>
 
             <Button Height="36"
                     HorizontalAlignment="Stretch"

--- a/src/Starward/Features/ViewHost/SystemTrayWindow.xaml.cs
+++ b/src/Starward/Features/ViewHost/SystemTrayWindow.xaml.cs
@@ -1,13 +1,26 @@
 ﻿using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using CommunityToolkit.Mvvm.Messaging;
+using Microsoft.Extensions.Logging;
+using Microsoft.UI;
 using Microsoft.UI.Windowing;
 using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Media;
+using Starward.Core;
+using Starward.Core.HoYoPlay;
+using Starward.Features.GameLauncher;
+using Starward.Features.GameSelector;
 using Starward.Features.Setting;
 using Starward.Frameworks;
 using Starward.Helpers;
 using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Diagnostics;
+using System.Globalization;
 using System.IO;
+using System.Linq;
 using Vanara.PInvoke;
 using Windows.Foundation;
 
@@ -18,15 +31,20 @@ namespace Starward.Features.ViewHost;
 public sealed partial class SystemTrayWindow : WindowEx
 {
 
+    private readonly ILogger<SystemTrayWindow> _logger = AppConfig.GetLogger<SystemTrayWindow>();
 
+    private readonly GameLauncherService _gameLauncherService = AppConfig.GetService<GameLauncherService>();
 
 
     public SystemTrayWindow()
     {
         this.InitializeComponent();
+        UpdateInstalledGames();
         InitializeWindow();
         SetTrayIcon();
         WeakReferenceMessenger.Default.Register<LanguageChangedMessage>(this, (_, _) => this.Bindings.Update());
+        WeakReferenceMessenger.Default.Register<InstalledGameRefreshedMessage>(this, (_, _) => UpdateInstalledGames());
+        WeakReferenceMessenger.Default.Register<GameInstallPathChangedMessage>(this, (_, _) => UpdateInstalledGames());
     }
 
 
@@ -77,6 +95,75 @@ public sealed partial class SystemTrayWindow : WindowEx
         catch { }
     }
 
+
+
+    public ObservableCollection<GameBizIcon> InstalledGames { get; set; } = new();
+
+
+    private void UpdateInstalledGames()
+    {
+        InstalledGames.Clear();
+        foreach (var display in GetGameServerArea(GameLauncherService.GetCachedGameInfos()))
+        {
+            foreach (var server in display.Servers)
+            {
+                var path = GameLauncherService.GetGameInstallPath(server.GameId);
+                if (Directory.Exists(path))
+                {
+                    server.MaskOpacity = 0;
+                    InstalledGames.Add(server);
+                }
+            }
+        }
+    }
+
+
+    private List<GameBizDisplay> GetGameServerArea(List<GameInfo> gameInfos)
+    {
+        var list = new List<GameBizDisplay>();
+
+        try
+        {
+            if (LanguageUtil.FilterLanguage(CultureInfo.CurrentUICulture.Name) is "zh-cn")
+            {
+                // 当前语言为简体中文时，游戏信息显示从中国官服获取的内容
+                foreach (var info in gameInfos)
+                {
+                    if (info.GameBiz.IsChinaServer() && !info.IsBilibiliServer())
+                    {
+                        list.Add(new GameBizDisplay { GameInfo = info });
+                    }
+                }
+            }
+            else
+            {
+                // 当前语言不为简体中文时，游戏信息显示从国际服获取的内容
+                foreach (var info in gameInfos)
+                {
+                    if (info.GameBiz.IsGlobalServer())
+                    {
+                        list.Add(new GameBizDisplay { GameInfo = info });
+                    }
+                }
+            }
+
+            // 分类每个游戏的服务器信息
+            foreach (var item in list)
+            {
+                string game = item.GameInfo.GameBiz.Game;
+                foreach (string suffix in (string[])["_cn", "_global", "_bilibili"])
+                {
+                    GameBiz biz = game + suffix;
+                    if (biz.IsKnown() || gameInfos.FirstOrDefault(x => x.GameBiz == biz) is GameInfo info)
+                    {
+                        item.Servers.Add(new GameBizIcon(biz));
+                    }
+                }
+            }
+        }
+        catch { }
+        return list;
+    }
 
 
 
@@ -136,4 +223,55 @@ public sealed partial class SystemTrayWindow : WindowEx
     }
 
 
+    private bool CheckGameExited(Process process)
+    {
+        try
+        {
+            if (process is null || process.HasExited)
+                return false;
+            return true;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    private async void Button_StartGame_Click(object sender, RoutedEventArgs e)
+    {
+        try
+        {
+            if (sender is Button button && button.Tag is GameBizIcon icon)
+            {
+                var process = await _gameLauncherService.StartGameAsync(GameId.FromGameBiz(icon.GameBiz)!)!;
+                if (process != null)
+                {
+                    button.IsEnabled = false;
+                    icon.MaskOpacity = 1;
+                    if (button.Content is Grid grid && VisualTreeHelper.GetChild(grid, 1) is TextBlock serverName)
+                    {
+                        serverName.Foreground = Application.Current.Resources["TextFillColorSecondaryBrush"] as SolidColorBrush;
+                        WeakReferenceMessenger.Default.Send(new GameStartedMessage());
+
+                        var timer = new DispatcherTimer { Interval = TimeSpan.FromSeconds(1) };
+                        timer.Tick += (s, args) =>
+                        {
+                            if (!CheckGameExited(process))
+                            {
+                                timer.Stop();
+                                icon.MaskOpacity = 0;
+                                serverName.Foreground = new SolidColorBrush(Colors.White);
+                                button.IsEnabled = true;
+                            }
+                        };
+                        timer.Start();
+                    }
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Start game");
+        }
+    }
 }


### PR DESCRIPTION
有总比没有好吧（）
把游戏选择器的统计已安装游戏的逻辑copy过来实现的

游戏已启动：
![屏幕截图 2025-04-10 162845](https://github.com/user-attachments/assets/dfded8c6-967b-4d24-a4b9-8f511e1183dc)
游戏未启动：
![屏幕截图 2025-04-10 162829](https://github.com/user-attachments/assets/b2292ae4-684f-4a4f-814c-1db76935e9a6)
