### PR TITLE
feat: add popup-window option

### DIFF
--- a/src/Starward.Language/Lang.Designer.cs
+++ b/src/Starward.Language/Lang.Designer.cs
@@ -2874,6 +2874,15 @@ namespace Starward.Language {
         }
         
         /// <summary>
+        ///   查找类似 Use Popup Window 的本地化字符串。
+        /// </summary>
+        public static string GameSettingPage_UsePopupWindow {
+            get {
+                return ResourceManager.GetString("GameSettingPage_UsePopupWindow", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   查找类似 Very High 的本地化字符串。
         /// </summary>
         public static string GameSettingPage_VeryHigh {

--- a/src/Starward.Language/Lang.resx
+++ b/src/Starward.Language/Lang.resx
@@ -2432,4 +2432,7 @@ You are welcome to submit the exported data to the following repository:</value>
   <data name="ScreenshotSetting_AutoCopyScreenshotFile" xml:space="preserve">
     <value>Auto Copy Screenshot File</value>
   </data>
+  <data name="GameSettingPage_UsePopupWindow" xml:space="preserve">
+    <value>Use Popup Window</value>
+  </data>
 </root>

--- a/src/Starward.Language/Lang.zh-CN.resx
+++ b/src/Starward.Language/Lang.zh-CN.resx
@@ -2432,4 +2432,7 @@
   <data name="ScreenshotSetting_AutoCopyScreenshotFile" xml:space="preserve">
     <value>自动复制截图文件</value>
   </data>
+  <data name="GameSettingPage_UsePopupWindow" xml:space="preserve">
+    <value>使用无边框窗口</value>
+  </data>
 </root>

--- a/src/Starward/AppConfig.cs
+++ b/src/Starward/AppConfig.cs
@@ -850,6 +850,27 @@ public static class AppConfig
     }
 
 
+    /// <summary>
+    /// 无边框窗口
+    /// </summary>
+    /// <param name="biz"></param>
+    /// <returns></returns>
+    public static bool GetUsePopupWindow(GameBiz biz)
+    {
+        return GetValue<bool>(false, $"use_popup_window_{biz}");
+    }
+
+    /// <summary>
+    /// 无边框窗口
+    /// </summary>
+    /// <param name="biz"></param>
+    /// <param name="value"></param>
+    public static void SetUsePopupWindow(GameBiz biz, bool value)
+    {
+        SetValue(value, $"use_popup_window_{biz}");
+    }
+
+
 
     public static long GetLastUidInGachaLogPage(GameBiz biz)
     {

--- a/src/Starward/Features/GameLauncher/GameLauncherService.cs
+++ b/src/Starward/Features/GameLauncher/GameLauncherService.cs
@@ -335,6 +335,11 @@ internal partial class GameLauncherService
                     arg += $" login_auth_ticket={ticket}";
                 }
             }
+            if (AppConfig.GetUsePopupWindow(gameId.GameBiz))
+            {
+                arg += " -popupwindow";
+            }
+
             if (gameId.GameBiz.Game is GameBiz.hk4e)
             {
                 GameSettingService.SetGenshinEnableHDR(gameId.GameBiz, AppConfig.EnableGenshinHDR);

--- a/src/Starward/Features/GameSetting/GameSettingPage.xaml
+++ b/src/Starward/Features/GameSetting/GameSettingPage.xaml
@@ -34,8 +34,13 @@
                     <CheckBox Margin="0,8,0,0"
                               Content="{x:Bind lang:Lang.GameSettingPage_FullScreen}"
                               IsChecked="{x:Bind EnableFullScreen, Mode=TwoWay}" />
+                    <!--  无边框窗口  -->
+                    <CheckBox Margin="0,8,0,0"
+                              Content="{x:Bind lang:Lang.GameSettingPage_UsePopupWindow}"
+                              IsChecked="{x:Bind UsePopupWindow, Mode=TwoWay}" />
                     <!--  自定义分辨率  -->
-                    <CheckBox Content="{x:Bind lang:Lang.GameSettingPage_CustomResolution}" IsChecked="{x:Bind EnableCustomResolution, Mode=TwoWay}" />
+                    <CheckBox Margin="0,8,0,0"
+                              Content="{x:Bind lang:Lang.GameSettingPage_CustomResolution}" IsChecked="{x:Bind EnableCustomResolution, Mode=TwoWay}" />
                     <ComboBox Name="ComboBox_Resolution"
                               Width="160"
                               Margin="0,8,0,0"

--- a/src/Starward/Features/GameSetting/GameSettingPage.xaml.cs
+++ b/src/Starward/Features/GameSetting/GameSettingPage.xaml.cs
@@ -121,6 +121,19 @@ public sealed partial class GameSettingPage : PageBase
     }
 
 
+    public bool UsePopupWindow
+    {
+        get;
+        set
+        {
+            if (SetProperty(ref field, value))
+            {
+                IsApplyButtonEnable = true;
+            }
+        }
+    }
+
+
 
     public bool EnableCustomResolution { get; set => SetProperty(ref field, value); }
 
@@ -226,6 +239,7 @@ public sealed partial class GameSettingPage : PageBase
                 UpdateHdrState(_displayInformation);
             }
             StartArgument = AppConfig.GetStartArgument(CurrentGameBiz);
+            UsePopupWindow = AppConfig.GetUsePopupWindow(CurrentGameBiz);
             var resolutionSetting = GameSettingService.GetGameResolutionSetting(CurrentGameBiz);
             if (resolutionSetting != null)
             {
@@ -404,6 +418,7 @@ public sealed partial class GameSettingPage : PageBase
                     Height = ResolutionHeight,
                 };
                 GameSettingService.SetGameResolutionSetting(CurrentGameBiz, model);
+                AppConfig.SetUsePopupWindow(CurrentGameBiz, UsePopupWindow);
             }
             if (IsLanguageSettingEnable)
             {


### PR DESCRIPTION
为程序加入「使用无边框窗口」启动选项。


<img width="599" height="239" alt="image" src="https://github.com/user-attachments/assets/22ce8251-6c22-4bbd-9856-e6fe4feb8c14" />

如果无边框设置项被选中，将会在启动项参数中传递`-popupwindow`。

**未在**除了*绝区零*以外的游戏内测试。考虑到其他三个游戏都是unity开发，理应遵守这一启动项。