### PR TITLE
feat: adjusted the order of some menus

### DIFF
--- a/src/Starward/Features/GameRecord/GameRecordPage.xaml
+++ b/src/Starward/Features/GameRecord/GameRecordPage.xaml
@@ -277,6 +277,23 @@
                         </Grid>
                     </NavigationViewItem.Content>
                 </NavigationViewItem>
+                <!--  旅行者札记  -->
+                <NavigationViewItem Name="NavigationViewItem_TravelersDiary"
+                                    Tag="TravelersDiaryPage"
+                                    Visibility="Collapsed">
+                    <NavigationViewItem.Content>
+                        <Grid Margin="{x:Bind NavigationViewItemContentMargin}" ColumnSpacing="12">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="Auto" />
+                                <ColumnDefinition />
+                            </Grid.ColumnDefinitions>
+                            <Image Width="20" Source="ms-appx:///Assets/Image/4bb2f9e21b6c64201692c4ea76a2faca_7020708978085976578.png" />
+                            <TextBlock Grid.Column="1"
+                                       Text="{x:Bind lang:Lang.HoyolabToolboxPage_TravelersDiary}"
+                                       TextTrimming="CharacterEllipsis" />
+                        </Grid>
+                    </NavigationViewItem.Content>
+                </NavigationViewItem>
                 <!--  深境螺旋  -->
                 <NavigationViewItem Name="NavigationViewItem_SpiralAbyss"
                                     Tag="SpiralAbyssPage"
@@ -328,9 +345,10 @@
                         </Grid>
                     </NavigationViewItem.Content>
                 </NavigationViewItem>
-                <!--  旅行者札记  -->
-                <NavigationViewItem Name="NavigationViewItem_TravelersDiary"
-                                    Tag="TravelersDiaryPage"
+
+                <!--  开拓月历  -->
+                <NavigationViewItem Name="NavigationViewItem_TrailblazeMonthlyCalendar"
+                                    Tag="TrailblazeCalendarPage"
                                     Visibility="Collapsed">
                     <NavigationViewItem.Content>
                         <Grid Margin="{x:Bind NavigationViewItemContentMargin}" ColumnSpacing="12">
@@ -338,14 +356,13 @@
                                 <ColumnDefinition Width="Auto" />
                                 <ColumnDefinition />
                             </Grid.ColumnDefinitions>
-                            <Image Width="20" Source="ms-appx:///Assets/Image/4bb2f9e21b6c64201692c4ea76a2faca_7020708978085976578.png" />
+                            <Image Width="20" Source="ms-appx:///Assets/Image/097aa51ae0b4bc0c9c9e6aca6dab0744_10826781894277788.png" />
                             <TextBlock Grid.Column="1"
-                                       Text="{x:Bind lang:Lang.HoyolabToolboxPage_TravelersDiary}"
+                                       Text="{x:Bind lang:Lang.HoyolabToolboxPage_TrailblazeMonthlyCalendar}"
                                        TextTrimming="CharacterEllipsis" />
                         </Grid>
                     </NavigationViewItem.Content>
                 </NavigationViewItem>
-
                 <!--  模拟宇宙  -->
                 <NavigationViewItem Name="NavigationViewItem_SimulatedUniverse"
                                     Tag="SimulatedUniversePage"
@@ -410,23 +427,6 @@
                             <Image Width="20" Source="ms-appx:///Assets/Image/ApocalypticShadow.png" />
                             <TextBlock Grid.Column="1"
                                        Text="{x:Bind lang:Lang.HoyolabToolboxPage_ApocalypticShadow}"
-                                       TextTrimming="CharacterEllipsis" />
-                        </Grid>
-                    </NavigationViewItem.Content>
-                </NavigationViewItem>
-                <!--  开拓月历  -->
-                <NavigationViewItem Name="NavigationViewItem_TrailblazeMonthlyCalendar"
-                                    Tag="TrailblazeCalendarPage"
-                                    Visibility="Collapsed">
-                    <NavigationViewItem.Content>
-                        <Grid Margin="{x:Bind NavigationViewItemContentMargin}" ColumnSpacing="12">
-                            <Grid.ColumnDefinitions>
-                                <ColumnDefinition Width="Auto" />
-                                <ColumnDefinition />
-                            </Grid.ColumnDefinitions>
-                            <Image Width="20" Source="ms-appx:///Assets/Image/097aa51ae0b4bc0c9c9e6aca6dab0744_10826781894277788.png" />
-                            <TextBlock Grid.Column="1"
-                                       Text="{x:Bind lang:Lang.HoyolabToolboxPage_TrailblazeMonthlyCalendar}"
                                        TextTrimming="CharacterEllipsis" />
                         </Grid>
                     </NavigationViewItem.Content>

--- a/src/Starward/Features/GameRecord/GameRecordPage.xaml.cs
+++ b/src/Starward/Features/GameRecord/GameRecordPage.xaml.cs
@@ -218,21 +218,21 @@ public sealed partial class GameRecordPage : PageBase
         else if (CurrentGameBiz.Game is GameBiz.hk4e)
         {
             NavigationViewItem_BattleChronicle.Visibility = Visibility.Visible;
+            NavigationViewItem_TravelersDiary.Visibility = Visibility.Visible;
             NavigationViewItem_SpiralAbyss.Visibility = Visibility.Visible;
             NavigationViewItem_ImaginariumTheater.Visibility = Visibility.Visible;
             NavigationViewItem_StygianOnslaught.Visibility = Visibility.Visible;
-            NavigationViewItem_TravelersDiary.Visibility = Visibility.Visible;
             // 原神战绩图片
             Image_BattleChronicle.Source = new BitmapImage(new("ms-appx:///Assets/Image/ced4deac2162690105bbc8baad2b51a3_4109616186965788891.png"));
         }
         else if (CurrentGameBiz.Game is GameBiz.hkrpg)
         {
             NavigationViewItem_BattleChronicle.Visibility = Visibility.Visible;
+            NavigationViewItem_TrailblazeMonthlyCalendar.Visibility = Visibility.Visible;
             NavigationViewItem_SimulatedUniverse.Visibility = Visibility.Visible;
             NavigationViewItem_ForgottenHall.Visibility = Visibility.Visible;
             NavigationViewItem_PureFiction.Visibility = Visibility.Visible;
             NavigationViewItem_ApocalypticShadow.Visibility = Visibility.Visible;
-            NavigationViewItem_TrailblazeMonthlyCalendar.Visibility = Visibility.Visible;
             // 铁道战绩图片
             Image_BattleChronicle.Source = new BitmapImage(new("ms-appx:///Assets/Image/ade9545750299456a3fcbc8c3b63521d_2941971308029698042.png"));
         }
@@ -502,15 +502,15 @@ public sealed partial class GameRecordPage : PageBase
                 }
                 var type = item.Tag switch
                 {
+                    nameof(TravelersDiaryPage) => typeof(TravelersDiaryPage),
                     nameof(SpiralAbyssPage) => typeof(SpiralAbyssPage),
                     nameof(ImaginariumTheaterPage) => typeof(ImaginariumTheaterPage),
                     nameof(StygianOnslaughtPage) => typeof(StygianOnslaughtPage),
-                    nameof(TravelersDiaryPage) => typeof(TravelersDiaryPage),
+                    nameof(TrailblazeCalendarPage) => typeof(TrailblazeCalendarPage),
                     nameof(SimulatedUniversePage) => typeof(SimulatedUniversePage),
                     nameof(ForgottenHallPage) => typeof(ForgottenHallPage),
                     nameof(PureFictionPage) => typeof(PureFictionPage),
                     nameof(ApocalypticShadowPage) => typeof(ApocalypticShadowPage),
-                    nameof(TrailblazeCalendarPage) => typeof(TrailblazeCalendarPage),
                     nameof(InterKnotMonthlyReportPage) => typeof(InterKnotMonthlyReportPage),
                     nameof(ShiyuDefensePage) => typeof(ShiyuDefensePage),
                     nameof(DeadlyAssaultPage) => typeof(DeadlyAssaultPage),

--- a/src/Starward/Features/ViewHost/MainView.xaml
+++ b/src/Starward/Features/ViewHost/MainView.xaml
@@ -88,17 +88,6 @@
                         </Border>
                     </NavigationViewItem.Content>
                 </NavigationViewItem>
-                <!--  抽卡记录  -->
-                <NavigationViewItem Name="NavigationViewItem_GachaLog" Tag="GachaLogPage">
-                    <NavigationViewItem.Icon>
-                        <FontIcon Glyph="&#xF4A5;" />
-                    </NavigationViewItem.Icon>
-                    <NavigationViewItem.Content>
-                        <Border Height="40">
-                            <TextBlock x:Name="TextBlock_GachaLog" VerticalAlignment="Center" />
-                        </Border>
-                    </NavigationViewItem.Content>
-                </NavigationViewItem>
                 <!--  工具箱  -->
                 <NavigationViewItem Name="NavigationViewItem_HoyolabToolbox" Tag="GameRecordPage">
                     <NavigationViewItem.Icon>
@@ -107,6 +96,17 @@
                     <NavigationViewItem.Content>
                         <Border Height="40">
                             <TextBlock x:Name="TextBlock_HoyolabToolbox" VerticalAlignment="Center" />
+                        </Border>
+                    </NavigationViewItem.Content>
+                </NavigationViewItem>
+                <!--  抽卡记录  -->
+                <NavigationViewItem Name="NavigationViewItem_GachaLog" Tag="GachaLogPage">
+                    <NavigationViewItem.Icon>
+                        <FontIcon Glyph="&#xF4A5;" />
+                    </NavigationViewItem.Icon>
+                    <NavigationViewItem.Content>
+                        <Border Height="40">
+                            <TextBlock x:Name="TextBlock_GachaLog" VerticalAlignment="Center" />
                         </Border>
                     </NavigationViewItem.Content>
                 </NavigationViewItem>

--- a/src/Starward/Features/ViewHost/MainView.xaml.cs
+++ b/src/Starward/Features/ViewHost/MainView.xaml.cs
@@ -124,8 +124,8 @@ public sealed partial class MainView : UserControl
         NavigationViewItem_Launcher.Visibility = CurrentGameFeatureConfig.SupportedPages.Contains(nameof(GameLauncherPage)).ToVisibility();
         NavigationViewItem_GameSetting.Visibility = CurrentGameFeatureConfig.SupportedPages.Contains(nameof(GameSettingPage)).ToVisibility();
         NavigationViewItem_Screenshot.Visibility = CurrentGameFeatureConfig.SupportedPages.Contains(nameof(ScreenshotPage)).ToVisibility();
-        NavigationViewItem_GachaLog.Visibility = CurrentGameFeatureConfig.SupportedPages.Contains(nameof(GachaLogPage)).ToVisibility();
         NavigationViewItem_HoyolabToolbox.Visibility = CurrentGameFeatureConfig.SupportedPages.Contains(nameof(GameRecordPage)).ToVisibility();
+        NavigationViewItem_GachaLog.Visibility = CurrentGameFeatureConfig.SupportedPages.Contains(nameof(GachaLogPage)).ToVisibility();
         NavigationViewItem_SelfQuery.Visibility = CurrentGameFeatureConfig.SupportedPages.Contains(nameof(SelfQueryPage)).ToVisibility();
 
         // 抽卡记录名称


### PR DESCRIPTION
调整部分菜单顺序，使其在四个游戏间更统一
其一，崩三有米哈游工具箱但无抽卡记录，使得在从崩三切换到其他三个游戏时，侧边栏在游戏截图和米游社工具箱中插入抽卡记录，因此将米游社工具箱与抽卡记录互换 其二，在米游社工具箱二级菜单中，原神旅行者札记和崩铁开拓月历处在最下方，而绝区零的绳网月报却固定在战绩下方，因此统一放在战绩下方