### PR TITLE
autobackup when exiting from system tray

### DIFF
--- a/src/Starward/Features/ViewHost/SystemTrayWindow.xaml.cs
+++ b/src/Starward/Features/ViewHost/SystemTrayWindow.xaml.cs
@@ -3,11 +3,14 @@ using CommunityToolkit.Mvvm.Input;
 using CommunityToolkit.Mvvm.Messaging;
 using Microsoft.UI.Windowing;
 using Microsoft.UI.Xaml;
+using Starward;
+using Starward.Features.Database;
 using Starward.Features.Setting;
 using Starward.Frameworks;
 using Starward.Helpers;
 using System;
 using System.IO;
+using System.Threading.Tasks;
 using Vanara.PInvoke;
 using Windows.Foundation;
 
@@ -124,8 +127,14 @@ public sealed partial class SystemTrayWindow : WindowEx
 
 
     [RelayCommand]
-    private void Exit()
+    private async void Exit()
     {
+        Hide();
+        trayIcon?.Dispose();
+        MainWindow.Current?.Close();
+        Task backupTask = Task.Run(DatabaseService.AutoBackupToAppDataLocal);
+        Task timeTask = Task.Delay(30000);
+        await Task.WhenAny(backupTask, timeTask);
         App.Current.Exit();
     }
 


### PR DESCRIPTION
0.14.0 Preview 4中增加的定时7天自动备份仅能在`关闭窗口选项`选择`完全退出`且点击主窗口关闭按钮关闭才能触发
`关闭窗口选项`选择`最小化到系统托盘`或是通过系统托盘退出按钮退出均不会触发定时自动定时备份
新增在通过系统托盘退出应用也能触发该自动定时自动备份