### PR TITLE
refactor: remove VP9 decoder registration method

### DIFF
--- a/src/Starward/Features/Background/AppBackground.xaml.cs
+++ b/src/Starward/Features/Background/AppBackground.xaml.cs
@@ -7,7 +7,6 @@ using Microsoft.Graphics.Canvas.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Media;
 using Microsoft.UI.Xaml.Media.Imaging;
-using Starward.Codec.VP9Decoder;
 using Starward.Core.HoYoPlay;
 using Starward.Features.ViewHost;
 using Starward.Helpers;
@@ -343,7 +342,6 @@ public sealed partial class AppBackground : UserControl
 
     private void StartMediaPlayer(string file)
     {
-        RegisterVP9Decoder();
         _mediaPlayer = new MediaPlayer
         {
             IsLoopingEnabled = true,
@@ -514,27 +512,6 @@ public sealed partial class AppBackground : UserControl
         _videoImageSource = null;
         _videoOverlayImage?.Dispose();
         _videoOverlayImage = null;
-        UnregisterVP9Decoder();
-    }
-
-
-    private static void RegisterVP9Decoder()
-    {
-        try
-        {
-            int hr = VP9Decoder.RegisterVP9DecoderLocal();
-        }
-        catch { }
-    }
-
-
-    private static void UnregisterVP9Decoder()
-    {
-        try
-        {
-            int hr = VP9Decoder.UnregisterVP9DecoderLocal();
-        }
-        catch { }
     }
 
 


### PR DESCRIPTION
尝试降低cpu占用。

对照组vs实验组：
<img width="1580" height="184" alt="image" src="https://github.com/user-attachments/assets/b3a0854f-e872-4a9e-9278-7de724f80f7e" />

移除手动注册的vp9解码可fallback为系统解码器，在我的情况下是NV decoder.

是否可以考虑让用户手动安装[VP9 decoder](https://apps.microsoft.com/detail/9n4d0msmp0pt?hl=zh-CN) （大部分情况下，此应用应该已经预装，而且玩这几个游戏显然是会有一个比较好的显卡的）？这样应该同时可以对Starward.Codec进行一个瘦身？