### PR TITLE
feature: auto-refresh data

### DIFF
--- a/src/Starward.Language/Lang.Designer.cs
+++ b/src/Starward.Language/Lang.Designer.cs
@@ -431,6 +431,24 @@ namespace Starward.Language {
         }
         
         /// <summary>
+        ///   查找类似 {0} Auto Refresh Completed 的本地化字符串。
+        /// </summary>
+        public static string Common_AutoRefreshCompleted {
+            get {
+                return ResourceManager.GetString("Common_AutoRefreshCompleted", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   查找类似 Auto Refresh on Startup 的本地化字符串。
+        /// </summary>
+        public static string Common_AutoRefreshOnStartup {
+            get {
+                return ResourceManager.GetString("Common_AutoRefreshOnStartup", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   查找类似 Cancel 的本地化字符串。
         /// </summary>
         public static string Common_Cancel {

--- a/src/Starward.Language/Lang.de-DE.resx
+++ b/src/Starward.Language/Lang.de-DE.resx
@@ -2655,4 +2655,10 @@ You are welcome to submit the exported data to the following repository:</value>
   <data name="AppBackground_VideoDecodingFailed" xml:space="preserve">
     <value>Video decoding failed</value>
   </data>
+  <data name="Common_AutoRefreshOnStartup" xml:space="preserve">
+    <value>Beim Start automatisch aktualisieren</value>
+  </data>
+  <data name="Common_AutoRefreshCompleted" xml:space="preserve">
+    <value>{0} Automatische Aktualisierung abgeschlossen</value>
+  </data>
 </root>

--- a/src/Starward.Language/Lang.es-ES.resx
+++ b/src/Starward.Language/Lang.es-ES.resx
@@ -2657,4 +2657,10 @@ You are welcome to submit the exported data to the following repository:</value>
   <data name="AppBackground_VideoDecodingFailed" xml:space="preserve">
     <value>Video decoding failed</value>
   </data>
+  <data name="Common_AutoRefreshOnStartup" xml:space="preserve">
+    <value>Actualización automática al iniciar</value>
+  </data>
+  <data name="Common_AutoRefreshCompleted" xml:space="preserve">
+    <value>{0} Actualización automática completada</value>
+  </data>
 </root>

--- a/src/Starward.Language/Lang.it-IT.resx
+++ b/src/Starward.Language/Lang.it-IT.resx
@@ -2657,4 +2657,10 @@ You are welcome to submit the exported data to the following repository:</value>
   <data name="AppBackground_VideoDecodingFailed" xml:space="preserve">
     <value>Video decoding failed</value>
   </data>
+  <data name="Common_AutoRefreshOnStartup" xml:space="preserve">
+    <value>Aggiornamento automatico all'avvio</value>
+  </data>
+  <data name="Common_AutoRefreshCompleted" xml:space="preserve">
+    <value>{0} Aggiornamento automatico completato</value>
+  </data>
 </root>

--- a/src/Starward.Language/Lang.ja-JP.resx
+++ b/src/Starward.Language/Lang.ja-JP.resx
@@ -2656,4 +2656,10 @@
   <data name="AppBackground_VideoDecodingFailed" xml:space="preserve">
     <value>Video decoding failed</value>
   </data>
+  <data name="Common_AutoRefreshOnStartup" xml:space="preserve">
+    <value>起動時に自動更新</value>
+  </data>
+  <data name="Common_AutoRefreshCompleted" xml:space="preserve">
+    <value>{0} 自動更新完了</value>
+  </data>
 </root>

--- a/src/Starward.Language/Lang.ko-KR.resx
+++ b/src/Starward.Language/Lang.ko-KR.resx
@@ -2657,4 +2657,10 @@
   <data name="AppBackground_VideoDecodingFailed" xml:space="preserve">
     <value>Video decoding failed</value>
   </data>
+  <data name="Common_AutoRefreshOnStartup" xml:space="preserve">
+    <value>시작 시 자동 새로고침</value>
+  </data>
+  <data name="Common_AutoRefreshCompleted" xml:space="preserve">
+    <value>{0} 자동 새로고침 완료</value>
+  </data>
 </root>

--- a/src/Starward.Language/Lang.resx
+++ b/src/Starward.Language/Lang.resx
@@ -2657,4 +2657,10 @@ You are welcome to submit the exported data to the following repository:</value>
   <data name="AppBackground_VideoDecodingFailed" xml:space="preserve">
     <value>Video decoding failed</value>
   </data>
+  <data name="Common_AutoRefreshOnStartup" xml:space="preserve">
+    <value>Auto Refresh on Startup</value>
+  </data>
+  <data name="Common_AutoRefreshCompleted" xml:space="preserve">
+    <value>{0} Auto Refresh Completed</value>
+  </data>
 </root>

--- a/src/Starward.Language/Lang.ru-RU.resx
+++ b/src/Starward.Language/Lang.ru-RU.resx
@@ -2677,4 +2677,10 @@ ChatGPT может допускать ошибки. Проверьте важн�
   <data name="AppBackground_VideoDecodingFailed" xml:space="preserve">
     <value>Video decoding failed</value>
   </data>
+  <data name="Common_AutoRefreshOnStartup" xml:space="preserve">
+    <value>Автообновление при запуске</value>
+  </data>
+  <data name="Common_AutoRefreshCompleted" xml:space="preserve">
+    <value>{0} Автообновление завершено</value>
+  </data>
 </root>

--- a/src/Starward.Language/Lang.th-TH.resx
+++ b/src/Starward.Language/Lang.th-TH.resx
@@ -2656,4 +2656,10 @@ You are welcome to submit the exported data to the following repository:</value>
   <data name="AppBackground_VideoDecodingFailed" xml:space="preserve">
     <value>Video decoding failed</value>
   </data>
+  <data name="Common_AutoRefreshOnStartup" xml:space="preserve">
+    <value>รีเฟรชอัตโนมัติเมื่อเริ่มต้น</value>
+  </data>
+  <data name="Common_AutoRefreshCompleted" xml:space="preserve">
+    <value>{0} รีเฟรชอัตโนมัติเสร็จสิ้น</value>
+  </data>
 </root>

--- a/src/Starward.Language/Lang.vi-VN.resx
+++ b/src/Starward.Language/Lang.vi-VN.resx
@@ -2654,4 +2654,10 @@ Bạn có chấp nhận rủi ro và tiếp tục?</value>
   <data name="AppBackground_VideoDecodingFailed" xml:space="preserve">
     <value>Video decoding failed</value>
   </data>
+  <data name="Common_AutoRefreshOnStartup" xml:space="preserve">
+    <value>Tự động làm mới khi khởi động</value>
+  </data>
+  <data name="Common_AutoRefreshCompleted" xml:space="preserve">
+    <value>{0} Tự động làm mới hoàn tất</value>
+  </data>
 </root>

--- a/src/Starward.Language/Lang.zh-CN.resx
+++ b/src/Starward.Language/Lang.zh-CN.resx
@@ -2657,4 +2657,10 @@
   <data name="AppBackground_VideoDecodingFailed" xml:space="preserve">
     <value>视频解码失败</value>
   </data>
+  <data name="Common_AutoRefreshOnStartup" xml:space="preserve">
+    <value>启动时自动刷新</value>
+  </data>
+  <data name="Common_AutoRefreshCompleted" xml:space="preserve">
+    <value>{0} 自动刷新完成</value>
+  </data>
 </root>

--- a/src/Starward.Language/Lang.zh-HK.resx
+++ b/src/Starward.Language/Lang.zh-HK.resx
@@ -2656,4 +2656,10 @@
   <data name="AppBackground_VideoDecodingFailed" xml:space="preserve">
     <value>Video decoding failed</value>
   </data>
+  <data name="Common_AutoRefreshOnStartup" xml:space="preserve">
+    <value>啟動時自動重新整理</value>
+  </data>
+  <data name="Common_AutoRefreshCompleted" xml:space="preserve">
+    <value>{0} 自動重新整理完成</value>
+  </data>
 </root>

--- a/src/Starward.Language/Lang.zh-TW.resx
+++ b/src/Starward.Language/Lang.zh-TW.resx
@@ -2657,4 +2657,10 @@
   <data name="AppBackground_VideoDecodingFailed" xml:space="preserve">
     <value>Video decoding failed</value>
   </data>
+  <data name="Common_AutoRefreshOnStartup" xml:space="preserve">
+    <value>啟動時自動重新整理</value>
+  </data>
+  <data name="Common_AutoRefreshCompleted" xml:space="preserve">
+    <value>{0} 自動重新整理完成</value>
+  </data>
 </root>

--- a/src/Starward/AppConfig.Setting.cs
+++ b/src/Starward/AppConfig.Setting.cs
@@ -384,6 +384,42 @@ public static partial class AppConfig
         set => SetValue(value);
     }
 
+    /// <summary>
+    /// 绳网月报自动刷新
+    /// </summary>
+    public static bool AutoRefreshInterKnotMonthlyReport
+    {
+        get => GetValue<bool>();
+        set => SetValue(value);
+    }
+
+    /// <summary>
+    /// 式舆防卫战自动刷新
+    /// </summary>
+    public static bool AutoRefreshShiyuDefense
+    {
+        get => GetValue<bool>();
+        set => SetValue(value);
+    }
+
+    /// <summary>
+    /// 危局强袭战自动刷新
+    /// </summary>
+    public static bool AutoRefreshDeadlyAssault
+    {
+        get => GetValue<bool>();
+        set => SetValue(value);
+    }
+
+    /// <summary>
+    /// 抽卡/调频记录自动刷新
+    /// </summary>
+    public static bool AutoRefreshGachaLog
+    {
+        get => GetValue<bool>();
+        set => SetValue(value);
+    }
+
 
     #endregion
 

--- a/src/Starward/Features/Gacha/GachaLogPage.xaml
+++ b/src/Starward/Features/Gacha/GachaLogPage.xaml
@@ -83,7 +83,11 @@
                             <!--  其他设置  -->
                             <TextBlock FontSize="16" Text="{x:Bind lang:Lang.GachaLogPage_OtherSettings}" />
 
-                            <!--  复制 URL  -->
+                            <!--  启动时自动刷新  -->
+                            <ToggleSwitch Header="{x:Bind lang:Lang.Common_AutoRefreshOnStartup}"
+                                          IsOn="{x:Bind AutoRefreshOnStartup, Mode=TwoWay}"
+                                          OffContent=""
+                                          OnContent="" />
                             <Button Margin="0,8,0,0" Command="{x:Bind CopyUrlCommand}">
                                 <StackPanel Orientation="Horizontal" Spacing="8">
                                     <FontIcon Name="FontIcon_CopyUrl"

--- a/src/Starward/Features/Gacha/GachaLogPage.xaml.cs
+++ b/src/Starward/Features/Gacha/GachaLogPage.xaml.cs
@@ -614,6 +614,20 @@ public sealed partial class GachaLogPage : PageBase
     } = AppConfig.GachaLanguage;
 
 
+    /// <summary>
+    /// 启动时自动刷新
+    /// </summary>
+    public bool AutoRefreshOnStartup
+    {
+        get => AppConfig.AutoRefreshGachaLog;
+        set
+        {
+            AppConfig.AutoRefreshGachaLog = value;
+            OnPropertyChanged();
+        }
+    }
+
+
 
     [RelayCommand]
     private async Task CopyUrlAsync()

--- a/src/Starward/Features/GameRecord/GameRecordPage.xaml.cs
+++ b/src/Starward/Features/GameRecord/GameRecordPage.xaml.cs
@@ -292,12 +292,16 @@ public sealed partial class GameRecordPage : PageBase
             var list = _gameRecordService.GetGameRoles(CurrentGameBiz);
             CurrentRole = role ?? list.FirstOrDefault();
             GameRoleList = list;
+
         }
         catch (Exception ex)
         {
             _logger.LogError(ex, "Load game roles ({gameBiz}).", CurrentGameBiz);
         }
     }
+
+
+
 
 
 
@@ -351,6 +355,7 @@ public sealed partial class GameRecordPage : PageBase
         {
             CurrentRole = role;
             _gameRecordService.SetLastSelectGameRecordRole(CurrentGameBiz, role);
+
             if (frame.SourcePageType?.Name is not nameof(LoginPage))
             {
                 NavigateTo(frame.SourcePageType, force_navigate: true);

--- a/src/Starward/Features/GameRecord/ZZZ/DeadlyAssaultPage.xaml
+++ b/src/Starward/Features/GameRecord/ZZZ/DeadlyAssaultPage.xaml
@@ -79,6 +79,11 @@
                     <TextBlock Text="{x:Bind lang:Lang.Common_Summary}" />
                 </StackPanel>
             </Button>
+            <ToggleSwitch Margin="12,8,0,0"
+                          Header="{x:Bind lang:Lang.Common_AutoRefreshOnStartup}"
+                          IsOn="{x:Bind AutoRefreshOnStartup, Mode=TwoWay}"
+                          OffContent=""
+                          OnContent="" />
         </StackPanel>
 
         <ListView Name="ListView_DeadlyAssault"

--- a/src/Starward/Features/GameRecord/ZZZ/DeadlyAssaultPage.xaml.cs
+++ b/src/Starward/Features/GameRecord/ZZZ/DeadlyAssaultPage.xaml.cs
@@ -69,6 +69,19 @@ public sealed partial class DeadlyAssaultPage : PageBase
     public DeadlyAssaultInfo? CurrentDeadlyAssault { get; set => SetProperty(ref field, value); }
 
 
+    /// <summary>
+    /// 启动时自动刷新
+    /// </summary>
+    public bool AutoRefreshOnStartup
+    {
+        get => AppConfig.AutoRefreshDeadlyAssault;
+        set
+        {
+            AppConfig.AutoRefreshDeadlyAssault = value;
+            OnPropertyChanged();
+        }
+    }
+
 
     private void InitializeDeadlyAssaultInfoData()
     {

--- a/src/Starward/Features/GameRecord/ZZZ/InterKnotMonthlyReportPage.xaml
+++ b/src/Starward/Features/GameRecord/ZZZ/InterKnotMonthlyReportPage.xaml
@@ -92,6 +92,11 @@
                     <MenuFlyout x:Name="MenuFlyout_GetDetails" Placement="RightEdgeAlignedTop" />
                 </Button.Flyout>
             </Button>
+            <ToggleSwitch Margin="12,8,0,0"
+                          Header="{x:Bind lang:Lang.Common_AutoRefreshOnStartup}"
+                          IsOn="{x:Bind AutoRefreshOnStartup, Mode=TwoWay}"
+                          OffContent=""
+                          OnContent="" />
         </StackPanel>
 
 

--- a/src/Starward/Features/GameRecord/ZZZ/InterKnotMonthlyReportPage.xaml.cs
+++ b/src/Starward/Features/GameRecord/ZZZ/InterKnotMonthlyReportPage.xaml.cs
@@ -94,6 +94,20 @@ public sealed partial class InterKnotMonthlyReportPage : PageBase
     private List<CalendarDayData> dayDataList;
 
 
+    /// <summary>
+    /// 启动时自动刷新
+    /// </summary>
+    public bool AutoRefreshOnStartup
+    {
+        get => AppConfig.AutoRefreshInterKnotMonthlyReport;
+        set
+        {
+            AppConfig.AutoRefreshInterKnotMonthlyReport = value;
+            OnPropertyChanged();
+        }
+    }
+
+
 
     private static readonly Dictionary<string, Color> actionColorMap = new Dictionary<string, Color>()
     {

--- a/src/Starward/Features/GameRecord/ZZZ/ShiyuDefensePage.xaml
+++ b/src/Starward/Features/GameRecord/ZZZ/ShiyuDefensePage.xaml
@@ -75,6 +75,11 @@
                     <TextBlock Text="{x:Bind lang:Lang.Common_Summary}" />
                 </StackPanel>
             </Button>
+            <ToggleSwitch Margin="12,8,0,0"
+                          Header="{x:Bind lang:Lang.Common_AutoRefreshOnStartup}"
+                          IsOn="{x:Bind AutoRefreshOnStartup, Mode=TwoWay}"
+                          OffContent=""
+                          OnContent="" />
         </StackPanel>
 
         <ListView Name="ListView_ShiyuDefense"

--- a/src/Starward/Features/GameRecord/ZZZ/ShiyuDefensePage.xaml.cs
+++ b/src/Starward/Features/GameRecord/ZZZ/ShiyuDefensePage.xaml.cs
@@ -73,6 +73,20 @@ public sealed partial class ShiyuDefensePage : PageBase
     public ShiyuDefenseInfoV2? CurrentShiyuDefenseV2 { get; set => SetProperty(ref field, value); }
 
 
+    /// <summary>
+    /// 启动时自动刷新
+    /// </summary>
+    public bool AutoRefreshOnStartup
+    {
+        get => AppConfig.AutoRefreshShiyuDefense;
+        set
+        {
+            AppConfig.AutoRefreshShiyuDefense = value;
+            OnPropertyChanged();
+        }
+    }
+
+
 
     private void InitializeShiyuDefenseInfoData()
     {


### PR DESCRIPTION
为多项数据加入自动刷新功能，避免历史战斗数据/排行榜数据忘记存档
<img width="1782" height="1005" alt="image" src="https://github.com/user-attachments/assets/81e9a1f6-d2bb-4ed5-8e94-de52953681a4" />


- 抽卡页面
<img width="456" height="312" alt="image" src="https://github.com/user-attachments/assets/d842fd68-ac0a-4e1f-81cd-128d8883b885" />

- 绝区零米游社数据
<img width="329" height="216" alt="image" src="https://github.com/user-attachments/assets/c1990fb2-e5d5-42b4-992a-44f91f738f6b" />

目前只能保证绝区零国服覆盖了测试。

可以做的其他探讨：
- 现在是`每次启动时`更新一次。是否要改成`关闭时`更新一次？抑或是要不要加入一天更新一次？还是以上要用户自选？
- 米的其他游戏需要跟进吗？（我不玩其他游戏所以无法测试）
- 原神/绝区零/崩坏3/星铁和它们对应的国际服/国服的抽卡更新，是一并更新，还是点开对应游戏标签页才更新？（现在打开了开关之后，如果某个游戏登陆过且抽卡记录数据库里有数据，那么会一并刷新一次）
- 其他的ui优化