### PR TITLE
fix: fix export excel

### DIFF
--- a/src/Starward/Features/Gacha/GenshinGachaService.cs
+++ b/src/Starward/Features/Gacha/GenshinGachaService.cs
@@ -158,11 +158,29 @@ internal class GenshinGachaService : GachaLogService
     {
         using var dapper = DatabaseService.CreateConnection();
         var list = GetGachaLogItemEx(uid);
+        var exportList = list.Select(item => new
+        {
+            item.Uid,
+            Id = item.IdText,
+            item.Time,
+            item.Name,
+            item.ItemType,
+            item.RankType,
+            GachaType = ((GenshinGachaType)item.GachaType).ToLocalization(),
+            item.Index,
+            item.Pity,
+        });
+        await MiniExcel.SaveAsAsync(output, exportList, overwriteFile: true);
+
+        // TODO: MiniExcel has a bug in SaveAsByTemplateAsync that corrupted the file.
+        // Wait for next version fix.
+        /*
         var template = Path.Combine(AppContext.BaseDirectory, @"Assets\Template\GachaLog.xlsx");
         if (File.Exists(template))
         {
             await MiniExcel.SaveAsByTemplateAsync(output, template, new { list });
         }
+        */
     }
 
 

--- a/src/Starward/Features/Gacha/ZZZGachaService.cs
+++ b/src/Starward/Features/Gacha/ZZZGachaService.cs
@@ -277,11 +277,29 @@ internal class ZZZGachaService : GachaLogService
     {
         using var dapper = DatabaseService.CreateConnection();
         var list = GetGachaLogItemEx(uid);
+        var exportList = list.Select(item => new
+        {
+            item.Uid,
+            Id = item.IdText,
+            item.Time,
+            item.Name,
+            item.ItemType,
+            item.RankType,
+            GachaType = ((ZZZGachaType)item.GachaType).ToLocalization(),
+            item.Index,
+            item.Pity,
+        });
+        await MiniExcel.SaveAsAsync(output, exportList, overwriteFile: true);
+
+        // TODO: MiniExcel has a bug in SaveAsByTemplateAsync that corrupted the file.
+        // Wait for next version fix.
+        /*
         var template = Path.Combine(AppContext.BaseDirectory, @"Assets\Template\GachaLog.xlsx");
         if (File.Exists(template))
         {
             await MiniExcel.SaveAsByTemplateAsync(output, template, new { list });
         }
+        */
     }
 
 


### PR DESCRIPTION
## Description

尝试修复导出的Excel抽卡记录损坏问题。


## Related Issue

#1728 
#744

## Root Cause

上游的[MiniExcel](https://github.com/mini-software/MiniExcel)库中的`SaveAsByTemplateAsync`有bug。

https://github.com/Scighost/Starward/blob/c739185b3549b4bab2fe7d4e3f01588407d078c6/src/Starward/Features/Gacha/ZZZGachaService.cs#L275-L286

我已经向上游发起[pr](https://github.com/mini-software/MiniExcel/pull/917)，测试后可成功打开文档。


<img width="1578" height="1109" alt="image" src="https://github.com/user-attachments/assets/e2d0807a-1467-4cf6-ad79-0f5336e8aaaa" />


（保底后的第一发是紫色，这是预期行为吗）
## Changes

暂时绕过模板处理，直接生成Excel，并注释掉现在出现问题的代码。
他们如果修好了就再改回来。

## Known Issue

因未使用模板，导出的文件将会缺少色彩
<img width="939" height="322" alt="image" src="https://github.com/user-attachments/assets/f78d5d05-eb5f-4ff7-b867-ac58ee6e9ddc" />

**仅在***绝区零*做了测试。

##  Extra 

<details>

<summary></summary>

换Npoi不知道是否可行。

如果导出为csv的话是不是也可以...

![11885C68BBE6C6958ECD7110A6732B60](https://github.com/user-attachments/assets/6bac1eb6-9a83-478e-bc8c-3e0078777d5e)

</details>