### PR TITLE
feat(gacha): 抽卡记录界面支持 Shift+滚轮 横向滚动

### DIFF
--- a/src/Starward/Features/Gacha/GachaLogPage.xaml
+++ b/src/Starward/Features/Gacha/GachaLogPage.xaml
@@ -291,7 +291,7 @@
             <ScrollViewer x:Name="ScrollViewer_GachaStats"
                           ScrollViewer.HorizontalScrollBarVisibility="Auto"
                           ScrollViewer.HorizontalScrollMode="Auto">
-                <Grid x:Name="Grid_GachaStats" Margin="20,0,20,16">
+                <Grid x:Name="Grid_GachaStats" Margin="20,0,20,16" Background="Transparent">
                     <ItemsControl x:Name="ItemsControl_GachaStats"
                                   x:Load="{x:Bind IsZZZGachaStatsCardVisible, Converter={StaticResource BoolReversedConverter}}"
                                   ItemsSource="{x:Bind DisplayGachaTypeStatsCollection}">

--- a/src/Starward/Features/Gacha/GachaLogPage.xaml.cs
+++ b/src/Starward/Features/Gacha/GachaLogPage.xaml.cs
@@ -2,6 +2,7 @@ using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using CommunityToolkit.Mvvm.Messaging;
 using Microsoft.Extensions.Logging;
+using Microsoft.UI.Input;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Media;
@@ -108,6 +109,7 @@ public sealed partial class GachaLogPage : PageBase
                 _ = UpdateGachaLogInternalAsync(m.Url);
             }
         });
+        Grid_GachaStats.PointerWheelChanged += Grid_GachaStats_PointerWheelChanged;
         Initialize();
         await UpdateWikiDataAsync();
     }
@@ -117,6 +119,7 @@ public sealed partial class GachaLogPage : PageBase
     protected override void OnUnloaded()
     {
         WeakReferenceMessenger.Default.UnregisterAll(this);
+        Grid_GachaStats.PointerWheelChanged -= Grid_GachaStats_PointerWheelChanged;
         if (DisplayGachaTypeStatsCollection is not null)
         {
             DisplayGachaTypeStatsCollection.Clear();
@@ -165,6 +168,17 @@ public sealed partial class GachaLogPage : PageBase
     }
 
 
+
+    private void Grid_GachaStats_PointerWheelChanged(object sender, Microsoft.UI.Xaml.Input.PointerRoutedEventArgs e)
+    {
+        var properties = e.GetCurrentPoint(Grid_GachaStats).Properties;
+        if (properties.IsHorizontalMouseWheel || InputKeyboardSource.GetKeyStateForCurrentThread(VirtualKey.Shift).HasFlag(Windows.UI.Core.CoreVirtualKeyStates.Down))
+        {
+            var delta = properties.MouseWheelDelta;
+            ScrollViewer_GachaStats.ChangeView(ScrollViewer_GachaStats.HorizontalOffset - delta, null, null);
+            e.Handled = true;
+        }
+    }
 
 
 


### PR DESCRIPTION
## 概述

本 PR 实现了 #1744 中提出的功能请求：在抽卡记录界面支持使用 **Shift + 鼠标滚轮** 进行横向滚动。

## 改动内容

- 在 GachaLogPage.xaml.cs 中添加了 PointerWheelChanged 事件处理
- 当用户按住 **Shift 键** 并滚动鼠标滚轮时，视图将进行横向滚动
- 滚动方向与滚轮方向一致（滚轮向上  向左滚动，滚轮向下  向右滚动）

## 实现细节

通过监听 ScrollViewer 的 PointerWheelChanged 事件，检测 Shift 键状态：
- 若 Shift 键按下，则拦截默认的垂直滚动行为
- 根据滚轮的 MouseWheelDelta 值计算横向滚动偏移量
- 调用 ChangeView 方法实现平滑的横向滚动

## 影响范围

- **仅影响** GachaLogPage（抽卡记录页面）
- **不影响** 其他页面的滚动行为
- **向后兼容**：未按 Shift 时，保持原有的垂直滚动行为

## 测试

- [x] Shift + 滚轮向上  向左滚动
- [x] Shift + 滚轮向下  向右滚动
- [x] 不按 Shift 时，保持原有垂直滚动行为

Closes #1744