### PR TITLE
feat: 添加米游社每日签到功能及视频背景播放失败回退

### DIFF
--- a/src/Starward.Core/GameRecord/CheckIn/CheckInInfo.cs
+++ b/src/Starward.Core/GameRecord/CheckIn/CheckInInfo.cs
@@ -1,0 +1,24 @@
+using System.Text.Json.Serialization;
+
+namespace Starward.Core.GameRecord.CheckIn;
+
+public class CheckInInfo
+{
+    [JsonPropertyName("total_sign_day")]
+    public int TotalSignDay { get; set; }
+
+    [JsonPropertyName("today")]
+    public string Today { get; set; }
+
+    [JsonPropertyName("is_sign")]
+    public bool IsSign { get; set; }
+
+    [JsonPropertyName("first_bind")]
+    public bool FirstBind { get; set; }
+
+    [JsonPropertyName("is_sub")]
+    public bool IsSub { get; set; }
+
+    [JsonPropertyName("region")]
+    public string Region { get; set; }
+}

--- a/src/Starward.Core/GameRecord/CheckIn/CheckInResult.cs
+++ b/src/Starward.Core/GameRecord/CheckIn/CheckInResult.cs
@@ -1,0 +1,24 @@
+using System.Text.Json.Serialization;
+
+namespace Starward.Core.GameRecord.CheckIn;
+
+public class CheckInResult
+{
+    [JsonPropertyName("code")]
+    public string Code { get; set; }
+
+    [JsonPropertyName("risk_code")]
+    public int RiskCode { get; set; }
+
+    [JsonPropertyName("gt")]
+    public string Gt { get; set; }
+
+    [JsonPropertyName("challenge")]
+    public string Challenge { get; set; }
+
+    [JsonPropertyName("success")]
+    public int Success { get; set; }
+
+    [JsonPropertyName("is_risk")]
+    public bool IsRisk { get; set; }
+}

--- a/src/Starward.Core/GameRecord/GameRecordClient.cs
+++ b/src/Starward.Core/GameRecord/GameRecordClient.cs
@@ -658,6 +658,32 @@ public abstract class GameRecordClient
 
 
 
+    #region Check-In
+
+
+    /// <summary>
+    /// 获取签到信息
+    /// </summary>
+    /// <param name="role"></param>
+    /// <param name="cancellationToken"></param>
+    /// <returns></returns>
+    public abstract Task<CheckIn.CheckInInfo> GetCheckInInfoAsync(GameRecordRole role, CancellationToken cancellationToken = default);
+
+
+    /// <summary>
+    /// 执行签到
+    /// </summary>
+    /// <param name="role"></param>
+    /// <param name="cancellationToken"></param>
+    /// <returns></returns>
+    public abstract Task<CheckIn.CheckInResult> CheckInAsync(GameRecordRole role, CancellationToken cancellationToken = default);
+
+
+    #endregion
+
+
+
+
     // 寰宇蝗灾
     // https://api-takumi-record.mihoyo.com/game_record/app/hkrpg/api/rogue_locust?server=prod_gf_cn&role_id={uid}&need_detail=true
 

--- a/src/Starward.Core/GameRecord/GameRecordJsonContext.cs
+++ b/src/Starward.Core/GameRecord/GameRecordJsonContext.cs
@@ -51,6 +51,8 @@ namespace Starward.Core.GameRecord;
 [JsonSerializable(typeof(miHoYoApiWrapper<BH3DailyNote>))]
 [JsonSerializable(typeof(miHoYoApiWrapper<ThresholdSimulationAbstractInfo>))]
 [JsonSerializable(typeof(miHoYoApiWrapper<ThresholdSimulationDetailInfo>))]
+[JsonSerializable(typeof(miHoYoApiWrapper<CheckIn.CheckInInfo>))]
+[JsonSerializable(typeof(miHoYoApiWrapper<CheckIn.CheckInResult>))]
 [JsonSerializable(typeof(DateTimeObjectJsonConverter.DateTimeObject))]
 internal partial class GameRecordJsonContext : JsonSerializerContext
 {

--- a/src/Starward.Core/GameRecord/HoyolabClient.cs
+++ b/src/Starward.Core/GameRecord/HoyolabClient.cs
@@ -965,4 +965,24 @@ public class HoyolabClient : GameRecordClient
 
 
 
+    #region Check-In
+
+
+    public override Task<CheckIn.CheckInInfo> GetCheckInInfoAsync(GameRecordRole role, CancellationToken cancellationToken = default)
+    {
+        throw new NotSupportedException("Check-in is only supported for Chinese server.");
+    }
+
+
+    public override Task<CheckIn.CheckInResult> CheckInAsync(GameRecordRole role, CancellationToken cancellationToken = default)
+    {
+        throw new NotSupportedException("Check-in is only supported for Chinese server.");
+    }
+
+
+    #endregion
+
+
+
+
 }

--- a/src/Starward/AppConfig.Setting.cs
+++ b/src/Starward/AppConfig.Setting.cs
@@ -384,6 +384,15 @@ public static partial class AppConfig
         set => SetValue(value);
     }
 
+    /// <summary>
+    /// 启动器打开时自动米游社签到
+    /// </summary>
+    public static bool EnableCheckInOnGameStart
+    {
+        get => GetValue<bool>();
+        set => SetValue(value);
+    }
+
 
     #endregion
 

--- a/src/Starward/Features/Setting/GeneralSetting.xaml
+++ b/src/Starward/Features/Setting/GeneralSetting.xaml
@@ -58,6 +58,11 @@
                           OffContent="{x:Bind lang:Lang.SettingPage_RegistryBasedGameAccountSwitchingFeature}"
                           OnContent="{x:Bind lang:Lang.SettingPage_RegistryBasedGameAccountSwitchingFeature}" />
 
+            <ToggleSwitch Margin="0,12,0,0"
+                          IsOn="{x:Bind EnableCheckInOnGameStart, Mode=TwoWay}"
+                          OffContent="启动器打开时自动米游社签到"
+                          OnContent="启动器打开时自动米游社签到" />
+
 
             <MenuFlyoutSeparator Margin="0,20,0,0" />
 

--- a/src/Starward/Features/Setting/GeneralSetting.xaml.cs
+++ b/src/Starward/Features/Setting/GeneralSetting.xaml.cs
@@ -205,6 +205,27 @@ public sealed partial class GeneralSetting : PageBase
 
 
 
+    #region 米游社签到
+
+
+
+    public bool EnableCheckInOnGameStart
+    {
+        get; set
+        {
+            if (SetProperty(ref field, value))
+            {
+                AppConfig.EnableCheckInOnGameStart = value;
+            }
+        }
+    } = AppConfig.EnableCheckInOnGameStart;
+
+
+
+    #endregion
+
+
+
     #region 系统视觉效果
 
 


### PR DESCRIPTION
## 变更内容

### 米游社每日签到
- 新增 CheckIn API 客户端（HyperionClient 国服实现，HoyolabClient 抛出不支持）
- 新增 CheckIn 数据模型（CheckInInfo / CheckInResult）
- GameRecordService 中实现批量签到逻辑，支持跳过已签到角色
- 签到请求间添加随机延迟避免触发风控
- 设置页面添加「启动器打开时自动米游社签到」开关
- MainWindow 启动时根据设置自动执行签到并 Toast 通知结果

### 视频背景回退
- 修复视频背景播放失败时未回退到静态背景的问题