### PR TITLE
bug:切换自定义背景功能若干相关问题处理。

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -400,3 +400,10 @@ FodyWeavers.xsd
 # JetBrains Rider
 *.sln.iml
 .idea/
+/.claude/settings.local.json
+/src/Starward/Starward.csproj.lscache
+/src/Starward.Core/Starward.Core.csproj.lscache
+/src/Starward.Language/Starward.Language.csproj.lscache
+/src/Starward.RPC/Starward.RPC.csproj.lscache
+/src/Starward.Setup/Starward.Setup.csproj.lscache
+/src/Starward.Setup.Core/Starward.Setup.Core.csproj.lscache

--- a/src/Starward/AppConfig.Setting.cs
+++ b/src/Starward/AppConfig.Setting.cs
@@ -66,12 +66,6 @@ public static partial class AppConfig
         set => SetValue(value);
     }
 
-    public static int VideoBgVolume
-    {
-        get => Math.Clamp(GetValue(0), 0, 100);
-        set => SetValue(value);
-    }
-
     [Obsolete("已不用", true)]
     public static bool UseOneBg
     {
@@ -587,6 +581,23 @@ public static partial class AppConfig
     public static void SetGameBackgroundIds(GameBiz biz, string? value)
     {
         SetValue(value, $"game_background_ids_{biz}");
+    }
+
+
+    /// <summary>
+    /// 背景视频音量，每个游戏区服独立设置
+    /// </summary>
+    public static int GetVideoBgVolume(GameBiz biz)
+    {
+        return Math.Clamp(GetValue(0, $"video_bg_volume_{biz}"), 0, 100);
+    }
+
+    /// <summary>
+    /// 背景视频音量，每个游戏区服独立设置
+    /// </summary>
+    public static void SetVideoBgVolume(GameBiz biz, int value)
+    {
+        SetValue(value, $"video_bg_volume_{biz}");
     }
 
 

--- a/src/Starward/Features/Background/AppBackground.xaml.cs
+++ b/src/Starward/Features/Background/AppBackground.xaml.cs
@@ -168,6 +168,8 @@ public sealed partial class AppBackground : UserControl
             {
                 DisposeVideoResource();
                 BackgroundImageSource = new BitmapImage(new Uri("ms-appx:///Assets/Image/UI_CutScene_1130320101A.png"));
+                CurrentGameBackground = null;
+                WeakReferenceMessenger.Default.Send(new BackgroundDisplayedMessage(null));
                 return;
             }
 
@@ -244,14 +246,20 @@ public sealed partial class AppBackground : UserControl
                     _lastBackgroundFile = filePath;
                     _lastScale = this.XamlRoot.GetUIScaleFactor();
                     CurrentGameBackground = gameBackground;
-                    if (!apiCancelled && gameBackground?.Type is not GameBackground.BACKGROUND_TYPE_CUSTOM)
+                    if (!apiCancelled && gameBackground is not null)
                     {
+                        // 记录最后使用的背景（包括自定义背景），用于下次启动、切换游戏或移动显示器时恢复。
                         AppConfig.SetBg(CurrentGameId.GameBiz, Path.GetFileName(filePath));
-                        var list = await _backgroundService.GetGameBackgroundsAsync(CurrentGameId);
-                        AppConfig.SetGameBackgroundIds(CurrentGameId.GameBiz, string.Join(',', list.Select(x => x.Id)));
+                        if (gameBackground.Type is not GameBackground.BACKGROUND_TYPE_CUSTOM)
+                        {
+                            var list = await _backgroundService.GetGameBackgroundsAsync(CurrentGameId);
+                            AppConfig.SetGameBackgroundIds(CurrentGameId.GameBiz, string.Join(',', list.Select(x => x.Id)));
+                        }
                     }
                 }
             }
+            // 通知启动器页面当前实际显示的背景，使播放/暂停按钮状态与之保持一致。
+            WeakReferenceMessenger.Default.Send(new BackgroundDisplayedMessage(CurrentGameBackground));
         }
         catch (OperationCanceledException) { }
         catch (COMException ex) when (ex.HResult == -2003292277)
@@ -357,9 +365,21 @@ public sealed partial class AppBackground : UserControl
 
     private CanvasImageSource? _videoImageSource;
 
-    private int videoBgVolume = AppConfig.VideoBgVolume;
-
     private SemaphoreSlim _videoSemaphore = new SemaphoreSlim(1, 1);
+
+
+    /// <summary>
+    /// 背景视频的实际音量（0-100）。每个游戏区服独立设置，关闭自定义背景时静音。
+    /// </summary>
+    private int GetEffectiveVideoVolume()
+    {
+        if (CurrentGameId is null)
+        {
+            return 0;
+        }
+        var biz = CurrentGameId.GameBiz;
+        return AppConfig.GetEnableCustomBg(biz) ? AppConfig.GetVideoBgVolume(biz) : 0;
+    }
 
 
     private void StartMediaPlayer(string file)
@@ -392,7 +412,7 @@ public sealed partial class AppBackground : UserControl
         _mediaPlayer = new MediaPlayer
         {
             IsLoopingEnabled = true,
-            Volume = videoBgVolume / 100.0,
+            Volume = GetEffectiveVideoVolume() / 100.0,
             IsMuted = false,
             IsVideoFrameServerEnabled = true,
             Source = MediaSource.CreateFromUri(new Uri(file))
@@ -613,8 +633,10 @@ public sealed partial class AppBackground : UserControl
     {
         try
         {
-            videoBgVolume = message.Volume;
-            _mediaPlayer?.Volume = message.Volume / 100d;
+            if (_mediaPlayer is not null)
+            {
+                _mediaPlayer.Volume = message.Volume / 100d;
+            }
         }
         catch { }
     }

--- a/src/Starward/Features/Background/BackgroundDisplayedMessage.cs
+++ b/src/Starward/Features/Background/BackgroundDisplayedMessage.cs
@@ -1,0 +1,19 @@
+using Starward.Core.HoYoPlay;
+
+namespace Starward.Features.Background;
+
+/// <summary>
+/// 由 <see cref="AppBackground"/> 在实际显示某个背景后发送，
+/// 通知启动器页面同步播放/暂停按钮等与当前背景相关的状态。
+/// </summary>
+internal class BackgroundDisplayedMessage
+{
+
+    public GameBackground? GameBackground { get; set; }
+
+    public BackgroundDisplayedMessage(GameBackground? gameBackground = null)
+    {
+        GameBackground = gameBackground;
+    }
+
+}

--- a/src/Starward/Features/Background/BackgroundService.cs
+++ b/src/Starward/Features/Background/BackgroundService.cs
@@ -100,12 +100,23 @@ public class BackgroundService
         {
             return null;
         }
-        if (TryGetCustomBgFilePath(gameId, out string? path))
+
+        string? lastBg = AppConfig.GetBg(gameId.GameBiz);
+        string? customBg = AppConfig.GetCustomBg(gameId.GameBiz);
+        if (!(lastBg == customBg && !AppConfig.GetEnableCustomBg(gameId.GameBiz)))
         {
-            return path;
+            string? path = GetBgFilePath(lastBg);
+            if (File.Exists(path))
+            {
+                return path;
+            }
         }
-        path = GetBgFilePath(AppConfig.GetBg(gameId.GameBiz));
-        return File.Exists(path) ? path : null;
+        // 回退到自定义背景
+        if (TryGetCustomBgFilePath(gameId, out string? custom))
+        {
+            return custom;
+        }
+        return null;
     }
 
 
@@ -136,13 +147,15 @@ public class BackgroundService
 
     public async Task<GameBackground?> GetSuggestedGameBackgroundAsync(GameId gameId, CancellationToken cancellationToken = default)
     {
-        if (TryGetCustomBgFilePath(gameId, out string? file))
+        string? lastBg = AppConfig.GetBg(gameId.GameBiz);
+        string? customBg = AppConfig.GetCustomBg(gameId.GameBiz);
+        // 上次使用的是自定义背景（或刚启用自定义背景尚未记录），直接返回，无需联网。
+        if (TryGetCustomBgFilePath(gameId, out string? file) && (string.IsNullOrWhiteSpace(lastBg) || lastBg == customBg))
         {
             return GameBackground.FromCustomFile(file);
         }
         List<GameBackground> backgrounds = await GetGameBackgroundsAsync(gameId, cancellationToken);
         GameBackground? bg = null;
-        string? lastBg = AppConfig.GetBg(gameId.GameBiz);
         string? lastBgIds = AppConfig.GetGameBackgroundIds(gameId.GameBiz);
         string firstBgId = backgrounds.FirstOrDefault()?.Id ?? string.Empty;
         if (!string.IsNullOrWhiteSpace(lastBg) && (lastBgIds?.StartsWith(firstBgId) ?? false))

--- a/src/Starward/Features/GameLauncher/GameLauncherPage.xaml.cs
+++ b/src/Starward/Features/GameLauncher/GameLauncherPage.xaml.cs
@@ -73,6 +73,7 @@ public sealed partial class GameLauncherPage : PageBase
         WeakReferenceMessenger.Default.Register<RemovableStorageDeviceChangedMessage>(this, OnRemovableStorageDeviceChanged);
         WeakReferenceMessenger.Default.Register<GameInstallTaskStartedMessage>(this, OnGameInstallTaskStarted);
         WeakReferenceMessenger.Default.Register<BackgroundChangedMessage>(this, OnBackgroundChanged);
+        WeakReferenceMessenger.Default.Register<BackgroundDisplayedMessage>(this, OnBackgroundDisplayed);
     }
 
 
@@ -780,6 +781,7 @@ public sealed partial class GameLauncherPage : PageBase
                 }
                 AppConfig.SetCustomBg(CurrentGameBiz, name);
                 AppConfig.SetEnableCustomBg(CurrentGameBiz, true);
+                AppConfig.SetBg(CurrentGameBiz, name);
                 WeakReferenceMessenger.Default.Send(new BackgroundChangedMessage());
             }
         }
@@ -862,6 +864,43 @@ public sealed partial class GameLauncherPage : PageBase
         {
             _ = InitializeBackgameImageSwitcherAsync();
         }
+    }
+
+
+    /// <summary>
+    /// 避免出现“显示静态海报但仍有播放/暂停按钮”的不一致状态。
+    /// </summary>
+    private void OnBackgroundDisplayed(object _, BackgroundDisplayedMessage message)
+    {
+        try
+        {
+            if (BackgroundImages is null)
+            {
+                return;
+            }
+            GameBackground? actual = message.GameBackground;
+            if (actual is not null && BackgroundImages.FirstOrDefault(x => x.Id == actual.Id) is GameBackground match)
+            {
+                int index = BackgroundImages.IndexOf(match);
+                if (index >= 0 && index != currentBackgroundImageIndex)
+                {
+                    currentBackgroundImageIndex = index;
+                    OnPropertyChanged(nameof(CurrentBackgroundImageIndex));
+                }
+                CanStopVideo = match.Type is GameBackground.BACKGROUND_TYPE_VIDEO;
+                if (CanStopVideo)
+                {
+                    match.StopVideo = actual.StopVideo;
+                    StartStopButtonIcon = actual.StopVideo ? PlayIcon : PauseIcon;
+                }
+            }
+            else
+            {
+                // 当前显示的是静态海报、回退图片或自定义图片等，没有可播放的视频。
+                CanStopVideo = false;
+            }
+        }
+        catch { }
     }
 
 

--- a/src/Starward/Features/GameLauncher/GameLauncherSettingDialog.xaml
+++ b/src/Starward/Features/GameLauncher/GameLauncherSettingDialog.xaml
@@ -568,6 +568,7 @@
                                     Height="32"
                                     Padding="0"
                                     Command="{x:Bind MuteCommand}"
+                                    IsEnabled="{x:Bind EnableCustomBg}"
                                     Style="{ThemeResource DateTimePickerFlyoutButtonStyle}">
                                 <Grid>
                                     <FontIcon FontSize="16"
@@ -579,6 +580,7 @@
                             <Slider Grid.Column="1"
                                     Width="200"
                                     HorizontalAlignment="Left"
+                                    IsEnabled="{x:Bind EnableCustomBg}"
                                     Maximum="100"
                                     Minimum="0"
                                     Value="{x:Bind VideoBgVolume, Mode=TwoWay}" />

--- a/src/Starward/Features/GameLauncher/GameLauncherSettingDialog.xaml.cs
+++ b/src/Starward/Features/GameLauncher/GameLauncherSettingDialog.xaml.cs
@@ -133,6 +133,7 @@ public sealed partial class GameLauncherSettingDialog : ContentDialog
     private async void GameLauncherSettingDialog_Loaded(object sender, RoutedEventArgs e)
     {
         CurrentGameBiz = CurrentGameId?.GameBiz ?? GameBiz.None;
+        WeakReferenceMessenger.Default.Register<AccentColorChangedMessage>(this, OnAccentColorChanged);
         CheckCanRepairGame();
         await InitializeBasicInfoAsync();
         InitializeStartArgument();
@@ -143,9 +144,33 @@ public sealed partial class GameLauncherSettingDialog : ContentDialog
 
     private void GameLauncherSettingDialog_Unloaded(object sender, RoutedEventArgs e)
     {
+        WeakReferenceMessenger.Default.UnregisterAll(this);
         LatestPackageGroups = null!;
         PreInstallPackageGroups = null!;
         FlipView_Settings.Items.Clear();
+    }
+
+
+    /// <summary>
+    /// 自定义背景的强调色变化后，刷新对话框自身的视觉树，
+    /// 使“选择”等使用强调色的控件实时生效
+    /// </summary>
+    private void OnAccentColorChanged(object _, AccentColorChangedMessage __)
+    {
+        try
+        {
+            if (this.Content is FrameworkElement ele)
+            {
+                ele.RequestedTheme = ele.ActualTheme switch
+                {
+                    ElementTheme.Light => ElementTheme.Dark,
+                    ElementTheme.Dark => ElementTheme.Light,
+                    _ => ElementTheme.Default,
+                };
+                ele.RequestedTheme = ElementTheme.Default;
+            }
+        }
+        catch { }
     }
 
 
@@ -757,6 +782,19 @@ public sealed partial class GameLauncherSettingDialog : ContentDialog
     partial void OnEnableCustomBgChanged(bool value)
     {
         AppConfig.SetEnableCustomBg(CurrentGameBiz, value);
+        if (value)
+        {
+            // 启用自定义背景时，将其记录为当前使用的背景。
+            string? customBg = AppConfig.GetCustomBg(CurrentGameBiz);
+            if (!string.IsNullOrWhiteSpace(customBg))
+            {
+                AppConfig.SetBg(CurrentGameBiz, customBg);
+            }
+        }
+        // 音量随自定义背景开关联动：关闭时静音，开启时恢复该游戏的音量。
+        WeakReferenceMessenger.Default.Send(new VideoBgVolumeChangedMessage(value ? _videoBgVolume : 0));
+        OnPropertyChanged(nameof(VideoBgVolume));
+        OnPropertyChanged(nameof(VideoBgVolumeButtonIcon));
         WeakReferenceMessenger.Default.Send(new BackgroundChangedMessage());
     }
 
@@ -777,7 +815,10 @@ public sealed partial class GameLauncherSettingDialog : ContentDialog
     {
         _EnableCustomBg = AppConfig.GetEnableCustomBg(CurrentGameBiz);
         CustomBg = AppConfig.GetCustomBg(CurrentGameBiz);
+        _videoBgVolume = AppConfig.GetVideoBgVolume(CurrentGameBiz);
         OnPropertyChanged(nameof(EnableCustomBg));
+        OnPropertyChanged(nameof(VideoBgVolume));
+        OnPropertyChanged(nameof(VideoBgVolumeButtonIcon));
     }
 
 
@@ -799,6 +840,7 @@ public sealed partial class GameLauncherSettingDialog : ContentDialog
             }
             CustomBg = name;
             AppConfig.SetCustomBg(CurrentGameBiz, name);
+            AppConfig.SetBg(CurrentGameBiz, name);
             WeakReferenceMessenger.Default.Send(new BackgroundChangedMessage());
         }
         catch (COMException ex)
@@ -849,20 +891,27 @@ public sealed partial class GameLauncherSettingDialog : ContentDialog
 
 
     /// <summary>
-    /// 视频背景音量
+    /// 视频背景音量，每个游戏区服独立设置。关闭自定义背景时显示为 0 且不可调整。
     /// </summary>
+    private int _videoBgVolume;
     public int VideoBgVolume
     {
-        get; set
+        get => EnableCustomBg ? _videoBgVolume : 0;
+        set
         {
-            if (SetProperty(ref field, value))
+            // 关闭自定义背景时不可调整。
+            if (!EnableCustomBg)
+            {
+                return;
+            }
+            if (SetProperty(ref _videoBgVolume, value))
             {
                 OnPropertyChanged(nameof(VideoBgVolumeButtonIcon));
                 WeakReferenceMessenger.Default.Send(new VideoBgVolumeChangedMessage(value));
-                AppConfig.VideoBgVolume = value;
+                AppConfig.SetVideoBgVolume(CurrentGameBiz, value);
             }
         }
-    } = AppConfig.VideoBgVolume;
+    }
 
 
 
@@ -933,6 +982,7 @@ public sealed partial class GameLauncherSettingDialog : ContentDialog
                 }
                 CustomBg = name;
                 AppConfig.SetCustomBg(CurrentGameBiz, name);
+                AppConfig.SetBg(CurrentGameBiz, name);
                 if (EnableCustomBg)
                 {
                     WeakReferenceMessenger.Default.Send(new BackgroundChangedMessage());


### PR DESCRIPTION
+ 切换自定义背景开关之后，强调色没有在“选择文件”和“切换”按钮两处生效。
    + 延用弱引用事件的通知方式进行了处理。
+ 自定义背景页面只有音量调节是全局共享。
    + 添加键值对给每个游戏单独做映射。
+ 关闭自定义背景功能时，如果之前在使用官方背景视频播放，那么暂停\播放按钮仍会存留。
+ 开启自定义背景功能时，通过下方指示器切换至官方图片，此时将软件移动到另一块dpi的屏幕时，直接恢复到自定义图片，可以推导出软件重启也会有相同的行为。
    + 原先的设计思路是，在不开启自定义背景的情况下，会记忆最后的使用壁纸，开启之后，只优先使用自定义壁纸，不记忆，但此时图片指示器可以正常使用，几个功能在交互上有一点冲突。目前将其修改为，保留记忆，去除优先使用。