### PR TITLE
Unify monthly report UX

### DIFF
--- a/src/Starward/Features/GameRecord/GameRecordService.cs
+++ b/src/Starward/Features/GameRecord/GameRecordService.cs
@@ -898,8 +898,8 @@ internal class GameRecordService
             return new List<InterKnotReportSummary>();
         }
         using var dapper = DatabaseService.CreateConnection();
-        var list = dapper.Query<InterKnotReportSummary>("SELECT * FROM ZZZInterKnotReportSummary WHERE Uid = @Uid ORDER BY DataMonth DESC;", new { role.Uid });
-        return list.ToList();
+        var values = dapper.Query<string>("SELECT Value FROM ZZZInterKnotReportSummary WHERE Uid = @Uid ORDER BY DataMonth DESC;", new { role.Uid });
+        return values.Select(v => JsonSerializer.Deserialize<InterKnotReportSummary>(v)!).ToList();
     }
 
 

--- a/src/Starward/Features/GameRecord/Genshin/TravelersDiaryPage.xaml.cs
+++ b/src/Starward/Features/GameRecord/Genshin/TravelersDiaryPage.xaml.cs
@@ -128,7 +128,7 @@ public sealed partial class TravelersDiaryPage : PageBase
             }
             CurrentSummary = await _gameRecordService.GetTravelersDiarySummaryAsync(gameRole);
             MenuFlyout_GetDetails.Items.Clear();
-            foreach (int month in CurrentSummary.OptionalMonth)
+            foreach (int month in Enumerable.Reverse(CurrentSummary.OptionalMonth))
             {
                 MenuFlyout_GetDetails.Items.Add(new MenuFlyoutItem
                 {

--- a/src/Starward/Features/GameRecord/ZZZ/InterKnotMonthlyReportPage.xaml
+++ b/src/Starward/Features/GameRecord/ZZZ/InterKnotMonthlyReportPage.xaml
@@ -114,7 +114,20 @@
                           Background="{ThemeResource CustomOverlayAcrylicBrush}"
                           CornerRadius="4"
                           RowSpacing="2">
+                        <Grid.RowDefinitions>
+                            <RowDefinition />
+                            <RowDefinition />
+                        </Grid.RowDefinitions>
                         <TextBlock FontSize="16" Text="{x:Bind DataMonth}" />
+                        <Image Grid.Row="1"
+                               Width="20"
+                               Height="20"
+                               HorizontalAlignment="Left"
+                               Source="ms-appx:///Assets/Image/IconCurrency.png" />
+                        <TextBlock Grid.Row="1"
+                                   Margin="24,0,0,0"
+                                   Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                   Text="{x:Bind local:InterKnotMonthlyReportPage.GetPolychromeCount(MonthData)}" />
                     </Grid>
                 </DataTemplate>
             </ListView.ItemTemplate>

--- a/src/Starward/Features/GameRecord/ZZZ/InterKnotMonthlyReportPage.xaml.cs
+++ b/src/Starward/Features/GameRecord/ZZZ/InterKnotMonthlyReportPage.xaml.cs
@@ -370,4 +370,12 @@ public sealed partial class InterKnotMonthlyReportPage : PageBase
 
 
 
+    public static int GetPolychromeCount(InterKnotReportMonthData monthData)
+    {
+        return monthData?.List?.FirstOrDefault(a => a.DataType == InterKnotReportDataType.PolychromesData)?.Count ?? 0;
+    }
+
+
+
+
 }


### PR DESCRIPTION
给绳网月报加了个菲林预览。另外调整原神获取详情数据MenuFlyout的顺序为近期在上，与其他游戏一致。

<img width="1484" height="837" alt="屏幕截图 2026-06-12 193154" src="https://github.com/user-attachments/assets/94c60963-ec05-46f3-abf1-3df1917c7f0f" />

close: #1351 
