### PR TITLE
show StarRailChallengePeak HardModeName and QuickCleared

### DIFF
--- a/src/Starward.Language/Lang.zh-CN.resx
+++ b/src/Starward.Language/Lang.zh-CN.resx
@@ -943,7 +943,7 @@
     <value>统计周期</value>
   </data>
   <data name="ForgottenHallPage_CyclesUsed" xml:space="preserve">
-    <value>使用轮：</value>
+    <value>使用轮次：</value>
   </data>
   <data name="ForgottenHallPage_TeamSetup" xml:space="preserve">
     <value>节点</value>

--- a/src/Starward.Language/Lang.zh-HK.resx
+++ b/src/Starward.Language/Lang.zh-HK.resx
@@ -942,7 +942,7 @@
     <value>統計週期</value>
   </data>
   <data name="ForgottenHallPage_CyclesUsed" xml:space="preserve">
-    <value>使用輪：</value>
+    <value>使用輪次：</value>
   </data>
   <data name="ForgottenHallPage_TeamSetup" xml:space="preserve">
     <value>節點</value>

--- a/src/Starward.Language/Lang.zh-TW.resx
+++ b/src/Starward.Language/Lang.zh-TW.resx
@@ -943,7 +943,7 @@
     <value>統計週期</value>
   </data>
   <data name="ForgottenHallPage_CyclesUsed" xml:space="preserve">
-    <value>使用輪：</value>
+    <value>使用輪次：</value>
   </data>
   <data name="ForgottenHallPage_TeamSetup" xml:space="preserve">
     <value>節點</value>

--- a/src/Starward/Features/GameRecord/StarRail/ApocalypticShadowPage.xaml
+++ b/src/Starward/Features/GameRecord/StarRail/ApocalypticShadowPage.xaml
@@ -395,7 +395,9 @@
                                             </ItemsControl>
                                         </StackPanel>
                                         <!--  总分  -->
-                                        <TextBlock HorizontalAlignment="Right" FontSize="12">
+                                        <TextBlock HorizontalAlignment="Right"
+                                                   FontSize="12"
+                                                   Visibility="{x:Bind IsFast, Converter={StaticResource BoolToVisibilityReversedConverter}}">
                                             <Run Foreground="{ThemeResource TextFillColorSecondaryBrush}" Text="{x:Bind lang:Lang.ApocalypticShadowPage_TotalScore}" />
                                             <Run Foreground="{ThemeResource AccentTextFillColorPrimaryBrush}" Text="{x:Bind TotalScore}" />
                                         </TextBlock>

--- a/src/Starward/Features/GameRecord/StarRail/ChallengePeakPage.xaml
+++ b/src/Starward/Features/GameRecord/StarRail/ChallengePeakPage.xaml
@@ -269,9 +269,19 @@
 
                     <StackPanel Grid.Row="0" Margin="20,12,0,0">
                         <!--  BOSS 名称  -->
-                        <TextBlock FontSize="16"
-                                   FontWeight="Bold"
-                                   Text="{x:Bind CurrentChallengePeakRecord.BossInfo.NameMi18n}" />
+                        <StackPanel Orientation="Horizontal">
+                            <StackPanel Orientation="Horizontal"
+                                        Visibility="{x:Bind CurrentChallengePeakRecord.BossRecord.HardMode, Converter={StaticResource BoolToVisibilityConverter}}">
+                                <TextBlock FontSize="16" FontWeight="Bold">
+                                    <Run Text="["/>
+                                    <Run Text="{x:Bind CurrentChallengePeakRecord.BossInfo.HardModeNameMi18n}"/>
+                                    <Run Text="]"/>
+                                </TextBlock>
+                            </StackPanel>
+                            <TextBlock FontSize="16"
+                                       FontWeight="Bold"
+                                       Text="{x:Bind CurrentChallengePeakRecord.BossInfo.NameMi18n}" />
+                        </StackPanel>
 
                         <!--  通关数据  -->
                         <StackPanel Margin="0,8,0,0"
@@ -393,9 +403,10 @@
 
                                     <StackPanel Grid.Row="0" Margin="20,12,0,0">
                                         <!--  BOSS 名称  -->
-                                        <TextBlock FontSize="16"
-                                                   FontWeight="Bold"
-                                                   Text="{x:Bind MobInfo.MonsterName}" />
+                                        <TextBlock FontSize="16" FontWeight="Bold">
+                                            <Run Text="{x:Bind MobInfo.Name}" />
+                                            <Run Text="{x:Bind MobInfo.MonsterName}" />
+                                        </TextBlock>
 
                                         <!--  通关数据  -->
                                         <StackPanel Margin="0,8,0,0"
@@ -407,7 +418,7 @@
                                                 <Run Text="{x:Bind MobRecord.RoundNum}" />
                                             </TextBlock>
 
-                                            <!--  已通关  -->
+                                            <!--  已通关 / 快速通关  -->
                                             <FontIcon Margin="20,2,4,0"
                                                       VerticalAlignment="Center"
                                                       FontSize="12"
@@ -415,7 +426,12 @@
                                                       Glyph="&#xEC61;" />
                                             <TextBlock Margin="0,0,4,0"
                                                        VerticalAlignment="Center"
-                                                       Text="{x:Bind lang:Lang.ChallengePeakPage_Cleared}" />
+                                                       Text="{x:Bind lang:Lang.ChallengePeakPage_Cleared}"
+                                                       Visibility="{x:Bind MobRecord.IsFast, Converter={StaticResource BoolToVisibilityReversedConverter}}" />
+                                            <TextBlock Margin="0,0,4,0"
+                                                       VerticalAlignment="Center"
+                                                       Text="{x:Bind lang:Lang.ForgottenHallPage_QuickCleared}"
+                                                       Visibility="{x:Bind MobRecord.IsFast, Converter={StaticResource BoolToVisibilityConverter}}" />
 
                                             <!--  星星数  -->
                                             <ItemsControl HorizontalAlignment="Right" ItemsSource="{x:Bind linq:Enumerable.Range(0, MobRecord.StarNum)}">
@@ -450,20 +466,29 @@
                                                 VerticalAlignment="Top"
                                                 Spacing="8"
                                                 Visibility="{x:Bind MobRecord.HasChallengeRecord, Converter={StaticResource BoolToVisibilityConverter}}">
-                                        <!--  通关时间  -->
-                                        <TextBlock Foreground="{ThemeResource TextFillColorSecondaryBrush}" Text="{x:Bind MobRecord.ChallengeTime.ToString('yyyy.MM.dd HH:mm', x:Null)}" />
-                                        <!--  队伍  -->
-                                        <ItemsControl Grid.Row="3"
-                                                      Grid.ColumnSpan="3"
-                                                      HorizontalAlignment="Left"
-                                                      ItemTemplate="{StaticResource StarRailTeamDataTemplate}"
-                                                      ItemsSource="{x:Bind MobRecord.Avatars}">
-                                            <ItemsControl.ItemsPanel>
-                                                <ItemsPanelTemplate>
-                                                    <StackPanel Orientation="Horizontal" Spacing="12" />
-                                                </ItemsPanelTemplate>
-                                            </ItemsControl.ItemsPanel>
-                                        </ItemsControl>
+                                        <StackPanel Spacing="8"
+                                                    Visibility="{x:Bind MobRecord.IsFast, Converter={StaticResource BoolToVisibilityReversedConverter}}">
+                                            <!--  通关时间  -->
+                                            <TextBlock Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                                       Text="{x:Bind MobRecord.ChallengeTime.ToString('yyyy.MM.dd HH:mm', x:Null)}" />
+                                            <!--  队伍  -->
+                                            <ItemsControl HorizontalAlignment="Left"
+                                                          ItemTemplate="{StaticResource StarRailTeamDataTemplate}"
+                                                          ItemsSource="{x:Bind MobRecord.Avatars}">
+                                                <ItemsControl.ItemsPanel>
+                                                    <ItemsPanelTemplate>
+                                                        <StackPanel Orientation="Horizontal" Spacing="12" />
+                                                    </ItemsPanelTemplate>
+                                                </ItemsControl.ItemsPanel>
+                                            </ItemsControl>
+                                        </StackPanel>
+
+                                        <!-- 快速通关 -->
+                                        <Image Width="120"
+                                               Margin="60,0,0,0"
+                                               HorizontalAlignment="Left"
+                                               Source="ms-appx:///Assets/Image/20004.png"
+                                               Visibility="{x:Bind MobRecord.IsFast, Converter={StaticResource BoolToVisibilityConverter}}" />
 
                                     </StackPanel>
 

--- a/src/Starward/Features/GameRecord/StarRail/PureFictionPage.xaml
+++ b/src/Starward/Features/GameRecord/StarRail/PureFictionPage.xaml
@@ -317,7 +317,9 @@
                                             </ItemsControl>
                                         </StackPanel>
                                         <!--  总分  -->
-                                        <TextBlock HorizontalAlignment="Right" FontSize="12">
+                                        <TextBlock HorizontalAlignment="Right"
+                                                   FontSize="12"
+                                                   Visibility="{x:Bind IsFast, Converter={StaticResource BoolToVisibilityReversedConverter}}">
                                             <Run Foreground="{ThemeResource TextFillColorSecondaryBrush}" Text="{x:Bind lang:Lang.ApocalypticShadowPage_TotalScore}" />
                                             <Run Foreground="{ThemeResource AccentTextFillColorPrimaryBrush}" Text="{x:Bind TotalScore}" />
                                         </TextBlock>


### PR DESCRIPTION
异相仲裁：王棋通关记录为绝境时显示绝境，与普通挑战记录区分；骑士关通关状态区分快速通关与已通关，快速通关时显示帕姆图片（与其他快速通关图片一致）。
未在标题提及：
末日幻影与虚构叙事中快速通关时隐藏总分显示（快速通关时总分为0，没有意义）。
文本“使用轮”调整为“使用轮次”（优化中文表达，与米游社一致）。
<img width="350" height="200" alt="屏幕截图 2026-07-16 123859" src="https://github.com/user-attachments/assets/bfe84470-e0a6-4301-b687-9d897e25edc3" /> → <img width="350" height="200" alt="屏幕截图 2026-07-16 124654" src="https://github.com/user-attachments/assets/1de63236-fe38-4a39-b6e6-f25d2daed51e" />
