### PR TITLE
fix: guard against invalid color primaries to prevent crash on VMs / ICC-less displays

### DIFF
--- a/src/Starward/Features/Screenshot/ScreenCaptureService.cs
+++ b/src/Starward/Features/Screenshot/ScreenCaptureService.cs
@@ -169,25 +169,34 @@ internal class ScreenCaptureService
             var iccStream = await displayInfo.GetColorProfileAsync();
             if (iccStream is null)
             {
-                return new ColorPrimaries
+                var p = new ColorPrimaries
                 {
                     Red = new Vector2((float)colorInfo.RedPrimary.X, (float)colorInfo.RedPrimary.Y),
                     Green = new Vector2((float)colorInfo.GreenPrimary.X, (float)colorInfo.GreenPrimary.Y),
                     Blue = new Vector2((float)colorInfo.BluePrimary.X, (float)colorInfo.BluePrimary.Y),
                     White = new Vector2((float)colorInfo.WhitePoint.X, (float)colorInfo.WhitePoint.Y),
                 };
+                return ArePrimariesValid(p) ? p : ColorPrimaries.BT709;
             }
             else
             {
                 byte[] iccData = new byte[iccStream.Size];
                 await iccStream.AsStream().ReadExactlyAsync(iccData).ConfigureAwait(false);
-                return ICCHelper.GetColorPrimariesFromIccData(iccData);
+                var p = ICCHelper.GetColorPrimariesFromIccData(iccData);
+                return ArePrimariesValid(p) ? p : ColorPrimaries.BT709;
             }
         }
         catch
         {
             return ColorPrimaries.BT709;
         }
+    }
+
+
+    private static bool ArePrimariesValid(ColorPrimaries p)
+    {
+        return Valid(p.Red) && Valid(p.Green) && Valid(p.Blue) && Valid(p.White);
+        static bool Valid(Vector2 v) => float.IsFinite(v.X) && float.IsFinite(v.Y) && v.X > 0f && v.X < 1f && v.Y > 0f && v.Y < 1f && v.X + v.Y <= 1f;
     }
 
 


### PR DESCRIPTION
## 问题

VM 或无 ICC profile 的设备上，`DisplayAdvancedColorInfo` 可能报告 NaN 或越界的色彩 primaries。保存截图时这些畸形值喂给 `ICCHelper`/lcms2，破坏 GC 堆，导致进程崩溃（`0xC0000005`）。

## 修复

`GetColorPrimariesFromDisplayInformationAsync` 内校验 primaries —— 任一 primary 非有限、超出 (0,1) 范围、或违反 x+y≤1 CIE 物理约束，则 fallback BT709，避免崩溃（不写畸形 ICC chunk）。

## 范围

单文件改动，纯逻辑兜底。不改默认值、UI、字符串 —— 正常显示器行为不变。