### PR TITLE
feat(gacha): 升级 UIGF 支持至 v4.2，新增千星奇域抽卡记录导入导出

### DIFF
--- a/src/Starward.Language/Lang.Designer.cs
+++ b/src/Starward.Language/Lang.Designer.cs
@@ -2223,11 +2223,11 @@ namespace Starward.Language {
         }
         
         /// <summary>
-        ///   查找类似 Import from UIGF v3.0 的本地化字符串。
+        ///   查找类似 Import from {0} 的本地化字符串。
         /// </summary>
-        public static string GachaLogPage_ImportFromUIGF30 {
+        public static string GachaLogPage_ImportFrom0 {
             get {
-                return ResourceManager.GetString("GachaLogPage_ImportFromUIGF30", resourceCulture);
+                return ResourceManager.GetString("GachaLogPage_ImportFrom0", resourceCulture);
             }
         }
 

--- a/src/Starward.Language/Lang.Designer.cs
+++ b/src/Starward.Language/Lang.Designer.cs
@@ -1951,7 +1951,16 @@ namespace Starward.Language {
                 return ResourceManager.GetString("GachaImportAndExportWindow_Count", resourceCulture);
             }
         }
-        
+
+        /// <summary>
+        ///   查找类似 Archive Type 的本地化字符串。
+        /// </summary>
+        public static string GachaImportAndExportWindow_ArchiveType {
+            get {
+                return ResourceManager.GetString("GachaImportAndExportWindow_ArchiveType", resourceCulture);
+            }
+        }
+
         /// <summary>
         ///   查找类似 Export 的本地化字符串。
         /// </summary>
@@ -2214,14 +2223,32 @@ namespace Starward.Language {
         }
         
         /// <summary>
-        ///   查找类似 Import from JSON 的本地化字符串。
+        ///   查找类似 Import from UIGF v3.0 的本地化字符串。
         /// </summary>
-        public static string GachaLogPage_ImportFromJson {
+        public static string GachaLogPage_ImportFromUIGF30 {
             get {
-                return ResourceManager.GetString("GachaLogPage_ImportFromJson", resourceCulture);
+                return ResourceManager.GetString("GachaLogPage_ImportFromUIGF30", resourceCulture);
             }
         }
-        
+
+        /// <summary>
+        ///   查找类似 UIGF v3.0 does not support Miliastra Wonderland Ode 的本地化字符串。
+        /// </summary>
+        public static string GachaLogPage_UIGF30DoesNotSupportMiliastraWonderlandOde {
+            get {
+                return ResourceManager.GetString("GachaLogPage_UIGF30DoesNotSupportMiliastraWonderlandOde", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   查找类似 This account has Miliastra Wonderland Ode records, but the UIGF v3.0 format cannot carry them. 的本地化字符串。
+        /// </summary>
+        public static string GachaLogPage_UIGF30DoesNotSupportMiliastraWonderlandOdeDesc {
+            get {
+                return ResourceManager.GetString("GachaLogPage_UIGF30DoesNotSupportMiliastraWonderlandOdeDesc", resourceCulture);
+            }
+        }
+
         /// <summary>
         ///   查找类似 Input URL 的本地化字符串。
         /// </summary>

--- a/src/Starward.Language/Lang.Designer.cs
+++ b/src/Starward.Language/Lang.Designer.cs
@@ -1951,16 +1951,7 @@ namespace Starward.Language {
                 return ResourceManager.GetString("GachaImportAndExportWindow_Count", resourceCulture);
             }
         }
-
-        /// <summary>
-        ///   查找类似 Archive Type 的本地化字符串。
-        /// </summary>
-        public static string GachaImportAndExportWindow_ArchiveType {
-            get {
-                return ResourceManager.GetString("GachaImportAndExportWindow_ArchiveType", resourceCulture);
-            }
-        }
-
+        
         /// <summary>
         ///   查找类似 Export 的本地化字符串。
         /// </summary>
@@ -2230,25 +2221,7 @@ namespace Starward.Language {
                 return ResourceManager.GetString("GachaLogPage_ImportFrom0", resourceCulture);
             }
         }
-
-        /// <summary>
-        ///   查找类似 UIGF v3.0 does not support Miliastra Wonderland Ode 的本地化字符串。
-        /// </summary>
-        public static string GachaLogPage_UIGF30DoesNotSupportMiliastraWonderlandOde {
-            get {
-                return ResourceManager.GetString("GachaLogPage_UIGF30DoesNotSupportMiliastraWonderlandOde", resourceCulture);
-            }
-        }
-
-        /// <summary>
-        ///   查找类似 This account has Miliastra Wonderland Ode records, but the UIGF v3.0 format cannot carry them. 的本地化字符串。
-        /// </summary>
-        public static string GachaLogPage_UIGF30DoesNotSupportMiliastraWonderlandOdeDesc {
-            get {
-                return ResourceManager.GetString("GachaLogPage_UIGF30DoesNotSupportMiliastraWonderlandOdeDesc", resourceCulture);
-            }
-        }
-
+        
         /// <summary>
         ///   查找类似 Input URL 的本地化字符串。
         /// </summary>
@@ -2417,6 +2390,24 @@ namespace Starward.Language {
         public static string GachaLogPage_SyncFromMiyousheAll {
             get {
                 return ResourceManager.GetString("GachaLogPage_SyncFromMiyousheAll", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   查找类似 UIGF v3.0 does not support Miliastra Wonderland Ode 的本地化字符串。
+        /// </summary>
+        public static string GachaLogPage_UIGF30DoesNotSupportMiliastraWonderlandOde {
+            get {
+                return ResourceManager.GetString("GachaLogPage_UIGF30DoesNotSupportMiliastraWonderlandOde", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   查找类似 This account has Miliastra Wonderland Ode records, but the UIGF v3.0 format cannot carry them. If you continue, those records will be left out of the exported file. To export them, use UIGF v4.2 instead. 的本地化字符串。
+        /// </summary>
+        public static string GachaLogPage_UIGF30DoesNotSupportMiliastraWonderlandOdeDesc {
+            get {
+                return ResourceManager.GetString("GachaLogPage_UIGF30DoesNotSupportMiliastraWonderlandOdeDesc", resourceCulture);
             }
         }
         

--- a/src/Starward.Language/Lang.de-DE.resx
+++ b/src/Starward.Language/Lang.de-DE.resx
@@ -59,46 +59,46 @@
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
-  <xsd:schema xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata" id="root">
-    <xsd:import namespace="http://www.w3.org/XML/1998/namespace"/>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
     <xsd:element name="root" msdata:IsDataSet="true">
       <xsd:complexType>
         <xsd:choice maxOccurs="unbounded">
           <xsd:element name="metadata">
             <xsd:complexType>
               <xsd:sequence>
-                <xsd:element name="value" type="xsd:string" minOccurs="0"/>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
               </xsd:sequence>
-              <xsd:attribute name="name" use="required" type="xsd:string"/>
-              <xsd:attribute name="type" type="xsd:string"/>
-              <xsd:attribute name="mimetype" type="xsd:string"/>
-              <xsd:attribute ref="xml:space"/>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
             </xsd:complexType>
           </xsd:element>
           <xsd:element name="assembly">
             <xsd:complexType>
-              <xsd:attribute name="alias" type="xsd:string"/>
-              <xsd:attribute name="name" type="xsd:string"/>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
             </xsd:complexType>
           </xsd:element>
           <xsd:element name="data">
             <xsd:complexType>
               <xsd:sequence>
-                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1"/>
-                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2"/>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
               </xsd:sequence>
-              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1"/>
-              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3"/>
-              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4"/>
-              <xsd:attribute ref="xml:space"/>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
             </xsd:complexType>
           </xsd:element>
           <xsd:element name="resheader">
             <xsd:complexType>
               <xsd:sequence>
-                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1"/>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
               </xsd:sequence>
-              <xsd:attribute name="name" type="xsd:string" use="required"/>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
             </xsd:complexType>
           </xsd:element>
         </xsd:choice>
@@ -342,9 +342,6 @@ Wenn Sie das Programm während der Dekomprimierung schließen, wird die Spieldat
   </data>
   <data name="GachaLogPage_ExportAs" xml:space="preserve">
     <value>Exportieren als</value>
-  </data>
-  <data name="GachaLogPage_ImportFromJson" xml:space="preserve">
-    <value>Aus JSON importieren</value>
   </data>
   <data name="GachaLogPage_ShowNoviceGachaType" xml:space="preserve">
     <value>Zeige Anfängerbanner</value>
@@ -2738,5 +2735,8 @@ Sie sind herzlich eingeladen, die exportierten Daten an das folgende Repository 
   </data>
   <data name="DailyNoteButton_StarRail_AccumulatedPoints" xml:space="preserve">
     <value>Angesammelte Punkte</value>
+  </data>
+  <data name="GachaLogPage_ImportFromJson" xml:space="preserve">
+    <value>Aus JSON importieren</value>
   </data>
 </root>

--- a/src/Starward.Language/Lang.es-ES.resx
+++ b/src/Starward.Language/Lang.es-ES.resx
@@ -59,46 +59,46 @@
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
-  <xsd:schema xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata" id="root">
-    <xsd:import namespace="http://www.w3.org/XML/1998/namespace"/>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
     <xsd:element name="root" msdata:IsDataSet="true">
       <xsd:complexType>
         <xsd:choice maxOccurs="unbounded">
           <xsd:element name="metadata">
             <xsd:complexType>
               <xsd:sequence>
-                <xsd:element name="value" type="xsd:string" minOccurs="0"/>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
               </xsd:sequence>
-              <xsd:attribute name="name" use="required" type="xsd:string"/>
-              <xsd:attribute name="type" type="xsd:string"/>
-              <xsd:attribute name="mimetype" type="xsd:string"/>
-              <xsd:attribute ref="xml:space"/>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
             </xsd:complexType>
           </xsd:element>
           <xsd:element name="assembly">
             <xsd:complexType>
-              <xsd:attribute name="alias" type="xsd:string"/>
-              <xsd:attribute name="name" type="xsd:string"/>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
             </xsd:complexType>
           </xsd:element>
           <xsd:element name="data">
             <xsd:complexType>
               <xsd:sequence>
-                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1"/>
-                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2"/>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
               </xsd:sequence>
-              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1"/>
-              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3"/>
-              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4"/>
-              <xsd:attribute ref="xml:space"/>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
             </xsd:complexType>
           </xsd:element>
           <xsd:element name="resheader">
             <xsd:complexType>
               <xsd:sequence>
-                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1"/>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
               </xsd:sequence>
-              <xsd:attribute name="name" type="xsd:string" use="required"/>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
             </xsd:complexType>
           </xsd:element>
         </xsd:choice>
@@ -342,9 +342,6 @@ cerrar el programa durante la descompresión causará corrupciones en los archiv
   </data>
   <data name="GachaLogPage_ExportAs" xml:space="preserve">
     <value>Exportar como</value>
-  </data>
-  <data name="GachaLogPage_ImportFromJson" xml:space="preserve">
-    <value>Importar desde JSON</value>
   </data>
   <data name="GachaLogPage_ShowNoviceGachaType" xml:space="preserve">
     <value>Mostrar tipo de Gacha principiante</value>
@@ -2740,5 +2737,8 @@ Puede enviar los datos exportados al siguiente repositorio:</value>
   </data>
   <data name="DailyNoteButton_StarRail_AccumulatedPoints" xml:space="preserve">
     <value>Puntos acumulados</value>
+  </data>
+  <data name="GachaLogPage_ImportFromJson" xml:space="preserve">
+    <value>Importar desde JSON</value>
   </data>
 </root>

--- a/src/Starward.Language/Lang.it-IT.resx
+++ b/src/Starward.Language/Lang.it-IT.resx
@@ -59,46 +59,46 @@
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
-  <xsd:schema xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata" id="root">
-    <xsd:import namespace="http://www.w3.org/XML/1998/namespace"/>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
     <xsd:element name="root" msdata:IsDataSet="true">
       <xsd:complexType>
         <xsd:choice maxOccurs="unbounded">
           <xsd:element name="metadata">
             <xsd:complexType>
               <xsd:sequence>
-                <xsd:element name="value" type="xsd:string" minOccurs="0"/>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
               </xsd:sequence>
-              <xsd:attribute name="name" use="required" type="xsd:string"/>
-              <xsd:attribute name="type" type="xsd:string"/>
-              <xsd:attribute name="mimetype" type="xsd:string"/>
-              <xsd:attribute ref="xml:space"/>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
             </xsd:complexType>
           </xsd:element>
           <xsd:element name="assembly">
             <xsd:complexType>
-              <xsd:attribute name="alias" type="xsd:string"/>
-              <xsd:attribute name="name" type="xsd:string"/>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
             </xsd:complexType>
           </xsd:element>
           <xsd:element name="data">
             <xsd:complexType>
               <xsd:sequence>
-                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1"/>
-                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2"/>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
               </xsd:sequence>
-              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1"/>
-              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3"/>
-              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4"/>
-              <xsd:attribute ref="xml:space"/>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
             </xsd:complexType>
           </xsd:element>
           <xsd:element name="resheader">
             <xsd:complexType>
               <xsd:sequence>
-                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1"/>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
               </xsd:sequence>
-              <xsd:attribute name="name" type="xsd:string" use="required"/>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
             </xsd:complexType>
           </xsd:element>
         </xsd:choice>
@@ -342,9 +342,6 @@ la chiusura del programma durante la decompressione causerà la corruzione dei f
   </data>
   <data name="GachaLogPage_ExportAs" xml:space="preserve">
     <value>Esporta come</value>
-  </data>
-  <data name="GachaLogPage_ImportFromJson" xml:space="preserve">
-    <value>Importa da JSON</value>
   </data>
   <data name="GachaLogPage_ShowNoviceGachaType" xml:space="preserve">
     <value>Mostra Tipo Gacha per Novizi</value>
@@ -2740,5 +2737,8 @@ Sei invitato a inviare i dati esportati al seguente repository:</value>
   </data>
   <data name="DailyNoteButton_StarRail_AccumulatedPoints" xml:space="preserve">
     <value>Punti accumulati</value>
+  </data>
+  <data name="GachaLogPage_ImportFromJson" xml:space="preserve">
+    <value>Importa da JSON</value>
   </data>
 </root>

--- a/src/Starward.Language/Lang.ja-JP.resx
+++ b/src/Starward.Language/Lang.ja-JP.resx
@@ -59,46 +59,46 @@
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
-  <xsd:schema xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata" id="root">
-    <xsd:import namespace="http://www.w3.org/XML/1998/namespace"/>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
     <xsd:element name="root" msdata:IsDataSet="true">
       <xsd:complexType>
         <xsd:choice maxOccurs="unbounded">
           <xsd:element name="metadata">
             <xsd:complexType>
               <xsd:sequence>
-                <xsd:element name="value" type="xsd:string" minOccurs="0"/>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
               </xsd:sequence>
-              <xsd:attribute name="name" use="required" type="xsd:string"/>
-              <xsd:attribute name="type" type="xsd:string"/>
-              <xsd:attribute name="mimetype" type="xsd:string"/>
-              <xsd:attribute ref="xml:space"/>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
             </xsd:complexType>
           </xsd:element>
           <xsd:element name="assembly">
             <xsd:complexType>
-              <xsd:attribute name="alias" type="xsd:string"/>
-              <xsd:attribute name="name" type="xsd:string"/>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
             </xsd:complexType>
           </xsd:element>
           <xsd:element name="data">
             <xsd:complexType>
               <xsd:sequence>
-                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1"/>
-                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2"/>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
               </xsd:sequence>
-              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1"/>
-              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3"/>
-              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4"/>
-              <xsd:attribute ref="xml:space"/>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
             </xsd:complexType>
           </xsd:element>
           <xsd:element name="resheader">
             <xsd:complexType>
               <xsd:sequence>
-                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1"/>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
               </xsd:sequence>
-              <xsd:attribute name="name" type="xsd:string" use="required"/>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
             </xsd:complexType>
           </xsd:element>
         </xsd:choice>
@@ -342,9 +342,6 @@
   </data>
   <data name="GachaLogPage_ExportAs" xml:space="preserve">
     <value>エクスポート</value>
-  </data>
-  <data name="GachaLogPage_ImportFromJson" xml:space="preserve">
-    <value>JSONからインポート</value>
   </data>
   <data name="GachaLogPage_ShowNoviceGachaType" xml:space="preserve">
     <value>初心者向けガチャの種類を表示</value>
@@ -2739,5 +2736,8 @@
   </data>
   <data name="DailyNoteButton_StarRail_AccumulatedPoints" xml:space="preserve">
     <value>累積ポイント</value>
+  </data>
+  <data name="GachaLogPage_ImportFromJson" xml:space="preserve">
+    <value>JSONからインポート</value>
   </data>
 </root>

--- a/src/Starward.Language/Lang.ko-KR.resx
+++ b/src/Starward.Language/Lang.ko-KR.resx
@@ -59,46 +59,46 @@
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
-  <xsd:schema xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata" id="root">
-    <xsd:import namespace="http://www.w3.org/XML/1998/namespace"/>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
     <xsd:element name="root" msdata:IsDataSet="true">
       <xsd:complexType>
         <xsd:choice maxOccurs="unbounded">
           <xsd:element name="metadata">
             <xsd:complexType>
               <xsd:sequence>
-                <xsd:element name="value" type="xsd:string" minOccurs="0"/>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
               </xsd:sequence>
-              <xsd:attribute name="name" use="required" type="xsd:string"/>
-              <xsd:attribute name="type" type="xsd:string"/>
-              <xsd:attribute name="mimetype" type="xsd:string"/>
-              <xsd:attribute ref="xml:space"/>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
             </xsd:complexType>
           </xsd:element>
           <xsd:element name="assembly">
             <xsd:complexType>
-              <xsd:attribute name="alias" type="xsd:string"/>
-              <xsd:attribute name="name" type="xsd:string"/>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
             </xsd:complexType>
           </xsd:element>
           <xsd:element name="data">
             <xsd:complexType>
               <xsd:sequence>
-                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1"/>
-                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2"/>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
               </xsd:sequence>
-              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1"/>
-              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3"/>
-              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4"/>
-              <xsd:attribute ref="xml:space"/>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
             </xsd:complexType>
           </xsd:element>
           <xsd:element name="resheader">
             <xsd:complexType>
               <xsd:sequence>
-                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1"/>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
               </xsd:sequence>
-              <xsd:attribute name="name" type="xsd:string" use="required"/>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
             </xsd:complexType>
           </xsd:element>
         </xsd:choice>
@@ -342,9 +342,6 @@
   </data>
   <data name="GachaLogPage_ExportAs" xml:space="preserve">
     <value>내보내기</value>
-  </data>
-  <data name="GachaLogPage_ImportFromJson" xml:space="preserve">
-    <value>JSON 에서 불러오기</value>
   </data>
   <data name="GachaLogPage_ShowNoviceGachaType" xml:space="preserve">
     <value>초보자 뽑기 표시</value>
@@ -2740,5 +2737,8 @@
   </data>
   <data name="DailyNoteButton_StarRail_AccumulatedPoints" xml:space="preserve">
     <value>누적 포인트</value>
+  </data>
+  <data name="GachaLogPage_ImportFromJson" xml:space="preserve">
+    <value>JSON 에서 불러오기</value>
   </data>
 </root>

--- a/src/Starward.Language/Lang.resx
+++ b/src/Starward.Language/Lang.resx
@@ -343,8 +343,8 @@ closing the program during decompression will cause game file corruption.</value
   <data name="GachaLogPage_ExportAs" xml:space="preserve">
     <value>Export as</value>
   </data>
-  <data name="GachaLogPage_ImportFromUIGF30" xml:space="preserve">
-    <value>Import from UIGF v3.0</value>
+  <data name="GachaLogPage_ImportFrom0" xml:space="preserve">
+    <value>Import from {0}</value>
   </data>
   <data name="GachaLogPage_UIGF30DoesNotSupportMiliastraWonderlandOde" xml:space="preserve">
     <value>UIGF v3.0 does not support Miliastra Wonderland Ode</value>

--- a/src/Starward.Language/Lang.resx
+++ b/src/Starward.Language/Lang.resx
@@ -343,8 +343,14 @@ closing the program during decompression will cause game file corruption.</value
   <data name="GachaLogPage_ExportAs" xml:space="preserve">
     <value>Export as</value>
   </data>
-  <data name="GachaLogPage_ImportFromJson" xml:space="preserve">
-    <value>Import from JSON</value>
+  <data name="GachaLogPage_ImportFromUIGF30" xml:space="preserve">
+    <value>Import from UIGF v3.0</value>
+  </data>
+  <data name="GachaLogPage_UIGF30DoesNotSupportMiliastraWonderlandOde" xml:space="preserve">
+    <value>UIGF v3.0 does not support Miliastra Wonderland Ode</value>
+  </data>
+  <data name="GachaLogPage_UIGF30DoesNotSupportMiliastraWonderlandOdeDesc" xml:space="preserve">
+    <value>This account has Miliastra Wonderland Ode records, but the UIGF v3.0 format cannot carry them. If you continue, those records will be left out of the exported file. To export them, use UIGF v4.2 instead.</value>
   </data>
   <data name="GachaLogPage_ShowNoviceGachaType" xml:space="preserve">
     <value>Show Novice Gacha Type</value>
@@ -1916,6 +1922,9 @@ You are welcome to submit the exported data to the following repository:</value>
   </data>
   <data name="GachaImportAndExportWindow_Count" xml:space="preserve">
     <value>Count</value>
+  </data>
+  <data name="GachaImportAndExportWindow_ArchiveType" xml:space="preserve">
+    <value>Archive Type</value>
   </data>
   <data name="GachaImportAndExportWindow_TimeServerTimeZone" xml:space="preserve">
     <value>Time (Server Time Zone)</value>

--- a/src/Starward.Language/Lang.resx
+++ b/src/Starward.Language/Lang.resx
@@ -1923,9 +1923,6 @@ You are welcome to submit the exported data to the following repository:</value>
   <data name="GachaImportAndExportWindow_Count" xml:space="preserve">
     <value>Count</value>
   </data>
-  <data name="GachaImportAndExportWindow_ArchiveType" xml:space="preserve">
-    <value>Archive Type</value>
-  </data>
   <data name="GachaImportAndExportWindow_TimeServerTimeZone" xml:space="preserve">
     <value>Time (Server Time Zone)</value>
   </data>

--- a/src/Starward.Language/Lang.ru-RU.resx
+++ b/src/Starward.Language/Lang.ru-RU.resx
@@ -59,46 +59,46 @@
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
-  <xsd:schema xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata" id="root">
-    <xsd:import namespace="http://www.w3.org/XML/1998/namespace"/>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
     <xsd:element name="root" msdata:IsDataSet="true">
       <xsd:complexType>
         <xsd:choice maxOccurs="unbounded">
           <xsd:element name="metadata">
             <xsd:complexType>
               <xsd:sequence>
-                <xsd:element name="value" type="xsd:string" minOccurs="0"/>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
               </xsd:sequence>
-              <xsd:attribute name="name" use="required" type="xsd:string"/>
-              <xsd:attribute name="type" type="xsd:string"/>
-              <xsd:attribute name="mimetype" type="xsd:string"/>
-              <xsd:attribute ref="xml:space"/>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
             </xsd:complexType>
           </xsd:element>
           <xsd:element name="assembly">
             <xsd:complexType>
-              <xsd:attribute name="alias" type="xsd:string"/>
-              <xsd:attribute name="name" type="xsd:string"/>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
             </xsd:complexType>
           </xsd:element>
           <xsd:element name="data">
             <xsd:complexType>
               <xsd:sequence>
-                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1"/>
-                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2"/>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
               </xsd:sequence>
-              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1"/>
-              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3"/>
-              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4"/>
-              <xsd:attribute ref="xml:space"/>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
             </xsd:complexType>
           </xsd:element>
           <xsd:element name="resheader">
             <xsd:complexType>
               <xsd:sequence>
-                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1"/>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
               </xsd:sequence>
-              <xsd:attribute name="name" type="xsd:string" use="required"/>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
             </xsd:complexType>
           </xsd:element>
         </xsd:choice>
@@ -342,9 +342,6 @@
   </data>
   <data name="GachaLogPage_ExportAs" xml:space="preserve">
     <value>Экспорт как</value>
-  </data>
-  <data name="GachaLogPage_ImportFromJson" xml:space="preserve">
-    <value>Импорт из JSON</value>
   </data>
   <data name="GachaLogPage_ShowNoviceGachaType" xml:space="preserve">
     <value>Показать тип гачи новичка</value>
@@ -2760,5 +2757,8 @@ ChatGPT может допускать ошибки. Проверьте важн�
   </data>
   <data name="DailyNoteButton_StarRail_AccumulatedPoints" xml:space="preserve">
     <value>Накопленные очки</value>
+  </data>
+  <data name="GachaLogPage_ImportFromJson" xml:space="preserve">
+    <value>Импорт из JSON</value>
   </data>
 </root>

--- a/src/Starward.Language/Lang.th-TH.resx
+++ b/src/Starward.Language/Lang.th-TH.resx
@@ -59,46 +59,46 @@
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
-  <xsd:schema xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata" id="root">
-    <xsd:import namespace="http://www.w3.org/XML/1998/namespace"/>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
     <xsd:element name="root" msdata:IsDataSet="true">
       <xsd:complexType>
         <xsd:choice maxOccurs="unbounded">
           <xsd:element name="metadata">
             <xsd:complexType>
               <xsd:sequence>
-                <xsd:element name="value" type="xsd:string" minOccurs="0"/>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
               </xsd:sequence>
-              <xsd:attribute name="name" use="required" type="xsd:string"/>
-              <xsd:attribute name="type" type="xsd:string"/>
-              <xsd:attribute name="mimetype" type="xsd:string"/>
-              <xsd:attribute ref="xml:space"/>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
             </xsd:complexType>
           </xsd:element>
           <xsd:element name="assembly">
             <xsd:complexType>
-              <xsd:attribute name="alias" type="xsd:string"/>
-              <xsd:attribute name="name" type="xsd:string"/>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
             </xsd:complexType>
           </xsd:element>
           <xsd:element name="data">
             <xsd:complexType>
               <xsd:sequence>
-                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1"/>
-                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2"/>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
               </xsd:sequence>
-              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1"/>
-              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3"/>
-              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4"/>
-              <xsd:attribute ref="xml:space"/>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
             </xsd:complexType>
           </xsd:element>
           <xsd:element name="resheader">
             <xsd:complexType>
               <xsd:sequence>
-                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1"/>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
               </xsd:sequence>
-              <xsd:attribute name="name" type="xsd:string" use="required"/>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
             </xsd:complexType>
           </xsd:element>
         </xsd:choice>
@@ -341,9 +341,6 @@
   </data>
   <data name="GachaLogPage_ExportAs" xml:space="preserve">
     <value>ส่งออกประวัติการสุ่ม</value>
-  </data>
-  <data name="GachaLogPage_ImportFromJson" xml:space="preserve">
-    <value>นำเข้าจาก JSON</value>
   </data>
   <data name="GachaLogPage_ShowNoviceGachaType" xml:space="preserve">
     <value>ชนิดการแสดงตู้สุ่มมือใหม่</value>
@@ -2734,5 +2731,8 @@
   </data>
   <data name="DailyNoteButton_StarRail_AccumulatedPoints" xml:space="preserve">
     <value>คะแนนสะสม</value>
+  </data>
+  <data name="GachaLogPage_ImportFromJson" xml:space="preserve">
+    <value>นำเข้าจาก JSON</value>
   </data>
 </root>

--- a/src/Starward.Language/Lang.vi-VN.resx
+++ b/src/Starward.Language/Lang.vi-VN.resx
@@ -59,46 +59,46 @@
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
-  <xsd:schema xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata" id="root">
-    <xsd:import namespace="http://www.w3.org/XML/1998/namespace"/>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
     <xsd:element name="root" msdata:IsDataSet="true">
       <xsd:complexType>
         <xsd:choice maxOccurs="unbounded">
           <xsd:element name="metadata">
             <xsd:complexType>
               <xsd:sequence>
-                <xsd:element name="value" type="xsd:string" minOccurs="0"/>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
               </xsd:sequence>
-              <xsd:attribute name="name" use="required" type="xsd:string"/>
-              <xsd:attribute name="type" type="xsd:string"/>
-              <xsd:attribute name="mimetype" type="xsd:string"/>
-              <xsd:attribute ref="xml:space"/>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
             </xsd:complexType>
           </xsd:element>
           <xsd:element name="assembly">
             <xsd:complexType>
-              <xsd:attribute name="alias" type="xsd:string"/>
-              <xsd:attribute name="name" type="xsd:string"/>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
             </xsd:complexType>
           </xsd:element>
           <xsd:element name="data">
             <xsd:complexType>
               <xsd:sequence>
-                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1"/>
-                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2"/>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
               </xsd:sequence>
-              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1"/>
-              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3"/>
-              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4"/>
-              <xsd:attribute ref="xml:space"/>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
             </xsd:complexType>
           </xsd:element>
           <xsd:element name="resheader">
             <xsd:complexType>
               <xsd:sequence>
-                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1"/>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
               </xsd:sequence>
-              <xsd:attribute name="name" type="xsd:string" use="required"/>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
             </xsd:complexType>
           </xsd:element>
         </xsd:choice>
@@ -342,9 +342,6 @@ việc đóng ứng dụng trong khi giải nén sẽ gây ra hư hỏng tập t
   </data>
   <data name="GachaLogPage_ExportAs" xml:space="preserve">
     <value>Xuất như</value>
-  </data>
-  <data name="GachaLogPage_ImportFromJson" xml:space="preserve">
-    <value>Nhập từ file JSON</value>
   </data>
   <data name="GachaLogPage_ShowNoviceGachaType" xml:space="preserve">
     <value>Hiển thị Gacha người mới</value>
@@ -2737,5 +2734,8 @@ Bạn có chấp nhận rủi ro và tiếp tục?</value>
   </data>
   <data name="DailyNoteButton_StarRail_AccumulatedPoints" xml:space="preserve">
     <value>Điểm tích lũy</value>
+  </data>
+  <data name="GachaLogPage_ImportFromJson" xml:space="preserve">
+    <value>Nhập từ file JSON</value>
   </data>
 </root>

--- a/src/Starward.Language/Lang.zh-CN.resx
+++ b/src/Starward.Language/Lang.zh-CN.resx
@@ -343,8 +343,8 @@
   <data name="GachaLogPage_ExportAs" xml:space="preserve">
     <value>导出为</value>
   </data>
-  <data name="GachaLogPage_ImportFromUIGF30" xml:space="preserve">
-    <value>从 UIGF v3.0 导入</value>
+  <data name="GachaLogPage_ImportFrom0" xml:space="preserve">
+    <value>从 {0} 导入</value>
   </data>
   <data name="GachaLogPage_UIGF30DoesNotSupportMiliastraWonderlandOde" xml:space="preserve">
     <value>UIGF v3.0 不支持千星奇域</value>

--- a/src/Starward.Language/Lang.zh-CN.resx
+++ b/src/Starward.Language/Lang.zh-CN.resx
@@ -59,46 +59,46 @@
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
-  <xsd:schema xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata" id="root">
-    <xsd:import namespace="http://www.w3.org/XML/1998/namespace"/>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
     <xsd:element name="root" msdata:IsDataSet="true">
       <xsd:complexType>
         <xsd:choice maxOccurs="unbounded">
           <xsd:element name="metadata">
             <xsd:complexType>
               <xsd:sequence>
-                <xsd:element name="value" type="xsd:string" minOccurs="0"/>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
               </xsd:sequence>
-              <xsd:attribute name="name" use="required" type="xsd:string"/>
-              <xsd:attribute name="type" type="xsd:string"/>
-              <xsd:attribute name="mimetype" type="xsd:string"/>
-              <xsd:attribute ref="xml:space"/>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
             </xsd:complexType>
           </xsd:element>
           <xsd:element name="assembly">
             <xsd:complexType>
-              <xsd:attribute name="alias" type="xsd:string"/>
-              <xsd:attribute name="name" type="xsd:string"/>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
             </xsd:complexType>
           </xsd:element>
           <xsd:element name="data">
             <xsd:complexType>
               <xsd:sequence>
-                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1"/>
-                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2"/>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
               </xsd:sequence>
-              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1"/>
-              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3"/>
-              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4"/>
-              <xsd:attribute ref="xml:space"/>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
             </xsd:complexType>
           </xsd:element>
           <xsd:element name="resheader">
             <xsd:complexType>
               <xsd:sequence>
-                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1"/>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
               </xsd:sequence>
-              <xsd:attribute name="name" type="xsd:string" use="required"/>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
             </xsd:complexType>
           </xsd:element>
         </xsd:choice>
@@ -1922,9 +1922,6 @@
   </data>
   <data name="GachaImportAndExportWindow_Count" xml:space="preserve">
     <value>数量</value>
-  </data>
-  <data name="GachaImportAndExportWindow_ArchiveType" xml:space="preserve">
-    <value>档案类型</value>
   </data>
   <data name="GachaImportAndExportWindow_TimeServerTimeZone" xml:space="preserve">
     <value>时间 (服务器时区)</value>

--- a/src/Starward.Language/Lang.zh-CN.resx
+++ b/src/Starward.Language/Lang.zh-CN.resx
@@ -343,8 +343,14 @@
   <data name="GachaLogPage_ExportAs" xml:space="preserve">
     <value>导出为</value>
   </data>
-  <data name="GachaLogPage_ImportFromJson" xml:space="preserve">
-    <value>从 JSON 导入</value>
+  <data name="GachaLogPage_ImportFromUIGF30" xml:space="preserve">
+    <value>从 UIGF v3.0 导入</value>
+  </data>
+  <data name="GachaLogPage_UIGF30DoesNotSupportMiliastraWonderlandOde" xml:space="preserve">
+    <value>UIGF v3.0 不支持千星奇域</value>
+  </data>
+  <data name="GachaLogPage_UIGF30DoesNotSupportMiliastraWonderlandOdeDesc" xml:space="preserve">
+    <value>当前账号存在千星奇域抽卡记录，但 UIGF v3.0 格式无法承载这部分数据。若选择继续，导出的文件将不包含千星奇域记录。如需导出，请改用 UIGF v4.2。</value>
   </data>
   <data name="GachaLogPage_ShowNoviceGachaType" xml:space="preserve">
     <value>显示新手卡池</value>
@@ -1916,6 +1922,9 @@
   </data>
   <data name="GachaImportAndExportWindow_Count" xml:space="preserve">
     <value>数量</value>
+  </data>
+  <data name="GachaImportAndExportWindow_ArchiveType" xml:space="preserve">
+    <value>档案类型</value>
   </data>
   <data name="GachaImportAndExportWindow_TimeServerTimeZone" xml:space="preserve">
     <value>时间 (服务器时区)</value>

--- a/src/Starward.Language/Lang.zh-HK.resx
+++ b/src/Starward.Language/Lang.zh-HK.resx
@@ -59,46 +59,46 @@
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
-  <xsd:schema xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata" id="root">
-    <xsd:import namespace="http://www.w3.org/XML/1998/namespace"/>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
     <xsd:element name="root" msdata:IsDataSet="true">
       <xsd:complexType>
         <xsd:choice maxOccurs="unbounded">
           <xsd:element name="metadata">
             <xsd:complexType>
               <xsd:sequence>
-                <xsd:element name="value" type="xsd:string" minOccurs="0"/>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
               </xsd:sequence>
-              <xsd:attribute name="name" use="required" type="xsd:string"/>
-              <xsd:attribute name="type" type="xsd:string"/>
-              <xsd:attribute name="mimetype" type="xsd:string"/>
-              <xsd:attribute ref="xml:space"/>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
             </xsd:complexType>
           </xsd:element>
           <xsd:element name="assembly">
             <xsd:complexType>
-              <xsd:attribute name="alias" type="xsd:string"/>
-              <xsd:attribute name="name" type="xsd:string"/>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
             </xsd:complexType>
           </xsd:element>
           <xsd:element name="data">
             <xsd:complexType>
               <xsd:sequence>
-                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1"/>
-                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2"/>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
               </xsd:sequence>
-              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1"/>
-              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3"/>
-              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4"/>
-              <xsd:attribute ref="xml:space"/>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
             </xsd:complexType>
           </xsd:element>
           <xsd:element name="resheader">
             <xsd:complexType>
               <xsd:sequence>
-                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1"/>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
               </xsd:sequence>
-              <xsd:attribute name="name" type="xsd:string" use="required"/>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
             </xsd:complexType>
           </xsd:element>
         </xsd:choice>
@@ -341,9 +341,6 @@
   </data>
   <data name="GachaLogPage_ExportAs" xml:space="preserve">
     <value>導出為</value>
-  </data>
-  <data name="GachaLogPage_ImportFromJson" xml:space="preserve">
-    <value>從 JSON 匯入</value>
   </data>
   <data name="GachaLogPage_ShowNoviceGachaType" xml:space="preserve">
     <value>顯示新手卡池</value>
@@ -2739,5 +2736,8 @@
   </data>
   <data name="DailyNoteButton_StarRail_AccumulatedPoints" xml:space="preserve">
     <value>週期積分</value>
+  </data>
+  <data name="GachaLogPage_ImportFromJson" xml:space="preserve">
+    <value>從 JSON 匯入</value>
   </data>
 </root>

--- a/src/Starward.Language/Lang.zh-TW.resx
+++ b/src/Starward.Language/Lang.zh-TW.resx
@@ -59,46 +59,46 @@
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
-  <xsd:schema xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata" id="root">
-    <xsd:import namespace="http://www.w3.org/XML/1998/namespace"/>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
     <xsd:element name="root" msdata:IsDataSet="true">
       <xsd:complexType>
         <xsd:choice maxOccurs="unbounded">
           <xsd:element name="metadata">
             <xsd:complexType>
               <xsd:sequence>
-                <xsd:element name="value" type="xsd:string" minOccurs="0"/>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
               </xsd:sequence>
-              <xsd:attribute name="name" use="required" type="xsd:string"/>
-              <xsd:attribute name="type" type="xsd:string"/>
-              <xsd:attribute name="mimetype" type="xsd:string"/>
-              <xsd:attribute ref="xml:space"/>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
             </xsd:complexType>
           </xsd:element>
           <xsd:element name="assembly">
             <xsd:complexType>
-              <xsd:attribute name="alias" type="xsd:string"/>
-              <xsd:attribute name="name" type="xsd:string"/>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
             </xsd:complexType>
           </xsd:element>
           <xsd:element name="data">
             <xsd:complexType>
               <xsd:sequence>
-                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1"/>
-                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2"/>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
               </xsd:sequence>
-              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1"/>
-              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3"/>
-              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4"/>
-              <xsd:attribute ref="xml:space"/>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
             </xsd:complexType>
           </xsd:element>
           <xsd:element name="resheader">
             <xsd:complexType>
               <xsd:sequence>
-                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1"/>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
               </xsd:sequence>
-              <xsd:attribute name="name" type="xsd:string" use="required"/>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
             </xsd:complexType>
           </xsd:element>
         </xsd:choice>
@@ -342,9 +342,6 @@
   </data>
   <data name="GachaLogPage_ExportAs" xml:space="preserve">
     <value>導出為</value>
-  </data>
-  <data name="GachaLogPage_ImportFromJson" xml:space="preserve">
-    <value>從 JSON 匯入</value>
   </data>
   <data name="GachaLogPage_ShowNoviceGachaType" xml:space="preserve">
     <value>顯示新手卡池</value>
@@ -2740,5 +2737,8 @@
   </data>
   <data name="DailyNoteButton_StarRail_AccumulatedPoints" xml:space="preserve">
     <value>週期積分</value>
+  </data>
+  <data name="GachaLogPage_ImportFromJson" xml:space="preserve">
+    <value>從 JSON 匯入</value>
   </data>
 </root>

--- a/src/Starward/Features/Gacha/GachaLogPage.xaml
+++ b/src/Starward/Features/Gacha/GachaLogPage.xaml
@@ -209,10 +209,10 @@
                                                         HorizontalAlignment="Stretch"
                                                         Command="{x:Bind ExportGachaLogCommand}"
                                                         CommandParameter="json"
-                                                        Content="UIGF v3.0"
+                                                        Content="{x:Bind LegacyFormatName}"
                                                         CornerRadius="0,4,4,0" />
                                             </Grid>
-                                            <!--  从 UIGF v3.0 导入  -->
+                                            <!--  从 UIGF v3.0 / SRGF v1.0 / JSON 导入  -->
                                             <Button x:Name="Button_Import"
                                                     HorizontalAlignment="Stretch"
                                                     Command="{x:Bind ImportGachaLogCommand}">
@@ -220,7 +220,7 @@
                                                     <FontIcon Margin="0,2,0,0"
                                                               FontSize="16"
                                                               Glyph="&#xEA52;" />
-                                                    <TextBlock Text="{x:Bind lang:Lang.GachaLogPage_ImportFromUIGF30}" />
+                                                    <TextBlock Text="{x:Bind LegacyImportText}" />
                                                 </StackPanel>
                                             </Button>
                                             <!--  分割线  -->

--- a/src/Starward/Features/Gacha/GachaLogPage.xaml
+++ b/src/Starward/Features/Gacha/GachaLogPage.xaml
@@ -209,10 +209,10 @@
                                                         HorizontalAlignment="Stretch"
                                                         Command="{x:Bind ExportGachaLogCommand}"
                                                         CommandParameter="json"
-                                                        Content="Json"
+                                                        Content="UIGF v3.0"
                                                         CornerRadius="0,4,4,0" />
                                             </Grid>
-                                            <!--  从 Json 导入  -->
+                                            <!--  从 UIGF v3.0 导入  -->
                                             <Button x:Name="Button_Import"
                                                     HorizontalAlignment="Stretch"
                                                     Command="{x:Bind ImportGachaLogCommand}">
@@ -220,14 +220,16 @@
                                                     <FontIcon Margin="0,2,0,0"
                                                               FontSize="16"
                                                               Glyph="&#xEA52;" />
-                                                    <TextBlock Text="{x:Bind lang:Lang.GachaLogPage_ImportFromJson}" />
+                                                    <TextBlock Text="{x:Bind lang:Lang.GachaLogPage_ImportFromUIGF30}" />
                                                 </StackPanel>
                                             </Button>
-                                            <!--  UIGF v4.0  -->
+                                            <!--  分割线  -->
+                                            <MenuFlyoutSeparator />
+                                            <!--  UIGF v4.2  -->
                                             <Button x:Name="Button_UIGF4"
                                                     HorizontalAlignment="Stretch"
                                                     Command="{x:Bind OpenUIGF4WindowCommand}"
-                                                    Content="UIGF v4.0" />
+                                                    Content="UIGF v4.2" />
                                         </StackPanel>
                                     </Flyout>
                                 </Button.Flyout>

--- a/src/Starward/Features/Gacha/GachaLogPage.xaml.cs
+++ b/src/Starward/Features/Gacha/GachaLogPage.xaml.cs
@@ -40,6 +40,8 @@ public sealed partial class GachaLogPage : PageBase
 
     private readonly GameRecordService _gameRecordService = AppConfig.GetService<GameRecordService>();
 
+    private readonly GenshinBeyondGachaService _genshinBeyondGachaService = AppConfig.GetService<GenshinBeyondGachaService>();
+
 
     private GachaLogService _gachaLogService;
 
@@ -985,6 +987,10 @@ public sealed partial class GachaLogPage : PageBase
                 return;
             }
             long uid = SelectUid.Value;
+            if (!await EnsureExportWithoutGenshinBeyondAsync(uid))
+            {
+                return;
+            }
             var ext = format switch
             {
                 "excel" => "xlsx",
@@ -1007,6 +1013,35 @@ public sealed partial class GachaLogPage : PageBase
             _logger.LogError(ex, "Export gacha log");
             InAppToast.MainWindow?.Error(ex);
         }
+    }
+
+
+
+
+    /// <summary>
+    /// UIGF v3.0 不支持千星奇域。若当前 Uid 存在千星奇域记录，提示用户这部分记录不会被导出，
+    /// 返回 false 表示用户选择取消，中断本次导出。
+    /// </summary>
+    private async Task<bool> EnsureExportWithoutGenshinBeyondAsync(long uid)
+    {
+        if (CurrentGameBiz.Game != GameBiz.hk4e)
+        {
+            return true;
+        }
+        if (!_genshinBeyondGachaService.GetUids().Contains(uid))
+        {
+            return true;
+        }
+        var dialog = new ContentDialog
+        {
+            Title = Lang.GachaLogPage_UIGF30DoesNotSupportMiliastraWonderlandOde,
+            Content = Lang.GachaLogPage_UIGF30DoesNotSupportMiliastraWonderlandOdeDesc,
+            PrimaryButtonText = Lang.Common_Continue,
+            SecondaryButtonText = Lang.Common_Cancel,
+            DefaultButton = ContentDialogButton.Secondary,
+            XamlRoot = this.XamlRoot,
+        };
+        return await dialog.ShowAsync() is ContentDialogResult.Primary;
     }
 
 

--- a/src/Starward/Features/Gacha/GachaLogPage.xaml.cs
+++ b/src/Starward/Features/Gacha/GachaLogPage.xaml.cs
@@ -58,6 +58,15 @@ public sealed partial class GachaLogPage : PageBase
     {
         base.OnNavigatedTo(e);
         GachaTypeText = GachaLogService.GetGachaLogText(CurrentGameBiz);
+        // 旧版导出对应的标准：原神是 UIGF v3.0，星铁是 SRGF v1.0，
+        // 绝区零没有对应标准，Starward 只是套用了同样的结构，故仍标为 JSON
+        LegacyFormatName = CurrentGameBiz.Game switch
+        {
+            GameBiz.hk4e => "UIGF v3.0",
+            GameBiz.hkrpg => "SRGF v1.0",
+            _ => "JSON",
+        };
+        LegacyImportText = string.Format(Lang.GachaLogPage_ImportFrom0, LegacyFormatName);
         if (CurrentGameBiz.Game == GameBiz.hk4e)
         {
             EnableGenshinGachaItemStats = true;
@@ -99,6 +108,18 @@ public sealed partial class GachaLogPage : PageBase
 
 
     public string GachaTypeText { get; set => SetProperty(ref field, value); }
+
+
+    /// <summary>
+    /// 旧版（非 UIGF v4.x）导出格式名称，随游戏变化
+    /// </summary>
+    public string LegacyFormatName { get; set => SetProperty(ref field, value); } = "JSON";
+
+
+    /// <summary>
+    /// 旧版导入按钮文字，如「从 UIGF v3.0 导入」
+    /// </summary>
+    public string LegacyImportText { get; set => SetProperty(ref field, value); } = "";
 
 
     public ObservableCollection<long> UidList { get; set => SetProperty(ref field, value); }

--- a/src/Starward/Features/Gacha/UIGF/GachaUidArchiveDisplay.cs
+++ b/src/Starward/Features/Gacha/UIGF/GachaUidArchiveDisplay.cs
@@ -26,7 +26,7 @@ public class GachaUidArchiveDisplay : ObservableObject
     /// </summary>
     public string ArchiveName => IsGenshinBeyond
         ? Lang.GenshinBeyondGachaPage_MiliastraWonderlandOde
-        : Game switch
+        : Game.Value switch
         {
             GameBiz.hk4e => Lang.GachaLogService_WishRecords,
             GameBiz.hkrpg => Lang.GachaLogService_WarpRecords,

--- a/src/Starward/Features/Gacha/UIGF/GachaUidArchiveDisplay.cs
+++ b/src/Starward/Features/Gacha/UIGF/GachaUidArchiveDisplay.cs
@@ -22,9 +22,17 @@ public class GachaUidArchiveDisplay : ObservableObject
     public bool IsGenshinBeyond { get; set; }
 
     /// <summary>
-    /// 列表中显示的档案名称，如「原神」「千星奇域」
+    /// 列表中显示的抽卡记录名称，如「祈愿记录」「千星奇域颂愿」
     /// </summary>
-    public string ArchiveName => IsGenshinBeyond ? Lang.GenshinBeyondGachaPage_MiliastraWonderlandOde : Game.ToGameName();
+    public string ArchiveName => IsGenshinBeyond
+        ? Lang.GenshinBeyondGachaPage_MiliastraWonderlandOde
+        : Game switch
+        {
+            GameBiz.hk4e => Lang.GachaLogService_WishRecords,
+            GameBiz.hkrpg => Lang.GachaLogService_WarpRecords,
+            GameBiz.nap => Lang.GachaLogService_SignalSearchRecords,
+            _ => Game.ToGameName(),
+        };
 
     public long Uid { get; set; }
 

--- a/src/Starward/Features/Gacha/UIGF/GachaUidArchiveDisplay.cs
+++ b/src/Starward/Features/Gacha/UIGF/GachaUidArchiveDisplay.cs
@@ -1,5 +1,6 @@
 using CommunityToolkit.Mvvm.ComponentModel;
 using Starward.Core;
+using Starward.Core.Gacha.Genshin;
 using Starward.Core.Gacha.StarRail;
 using Starward.Core.Gacha.ZZZ;
 using System;
@@ -14,6 +15,16 @@ public class GachaUidArchiveDisplay : ObservableObject
     public GameBiz Game { get; set; }
 
     public string GameIcon { get; set; }
+
+    /// <summary>
+    /// 千星奇域与原神本体共用 Uid，需要单独成行，故用此标记区分
+    /// </summary>
+    public bool IsGenshinBeyond { get; set; }
+
+    /// <summary>
+    /// 列表中显示的档案名称，如「原神」「千星奇域」
+    /// </summary>
+    public string ArchiveName => IsGenshinBeyond ? Lang.GenshinBeyondGachaPage_MiliastraWonderlandOde : Game.ToGameName();
 
     public long Uid { get; set; }
 
@@ -31,6 +42,8 @@ public class GachaUidArchiveDisplay : ObservableObject
     public List<StarRailGachaItem>? hkrpgList { get; set; }
 
     public List<ZZZGachaItem>? napList { get; set; }
+
+    public List<GenshinBeyondGachaItem>? hk4eUgcList { get; set; }
 
 
     public int Timezone

--- a/src/Starward/Features/Gacha/UIGF/UIGF4File.cs
+++ b/src/Starward/Features/Gacha/UIGF/UIGF4File.cs
@@ -1,4 +1,4 @@
-using Starward.Core.Gacha;
+using Starward.Core.Gacha.Genshin;
 using Starward.Core.Gacha.StarRail;
 using Starward.Core.Gacha.ZZZ;
 using System;
@@ -26,6 +26,13 @@ public class UIGF4File
     public List<UIGF4GachaArchive<ZZZGachaItem>>? napGachaArchives { get; set; }
 
 
+    /// <summary>
+    /// 千星奇域，UIGF v4.2 新增
+    /// </summary>
+    [JsonPropertyName("hk4e_ugc")]
+    public List<UIGF4GachaArchive<GenshinBeyondGachaItem>>? hk4eUgcGachaArchives { get; set; }
+
+
 
     public UIGF4File()
     {
@@ -33,6 +40,7 @@ public class UIGF4File
         hk4eGachaArchives = new();
         hkrpgGachaArchives = new();
         napGachaArchives = new();
+        hk4eUgcGachaArchives = new();
     }
 
 
@@ -60,7 +68,7 @@ public class UIGF4FileInfo
 
 
     [JsonPropertyName("version")]
-    public string Version { get; set; } = "v4.0";
+    public string Version { get; set; } = "v4.2";
 
 
     public UIGF4FileInfo()
@@ -75,7 +83,10 @@ public class UIGF4FileInfo
 
 
 
-public class UIGF4GachaArchive<T> where T : GachaLogItem
+/// <summary>
+/// 千星奇域的记录不继承 <see cref="Starward.Core.Gacha.GachaLogItem"/>，故此处不约束泛型参数
+/// </summary>
+public class UIGF4GachaArchive<T>
 {
 
     [JsonPropertyName("uid")]

--- a/src/Starward/Features/Gacha/UIGF/UIGF4File.cs
+++ b/src/Starward/Features/Gacha/UIGF/UIGF4File.cs
@@ -98,8 +98,13 @@ public class UIGF4GachaArchive<T>
     public int Timezone { get; set; }
 
 
+    /// <summary>
+    /// 语言代码。标准未将其列入 required，但定义了 enum，空字符串不是合法取值，
+    /// 因此无法确定语言时必须整个省略该字段，而不能写 ""。
+    /// </summary>
     [JsonPropertyName("lang")]
-    public string Lang { get; set; }
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? Lang { get; set; }
 
 
     [JsonPropertyName("list")]

--- a/src/Starward/Features/Gacha/UIGF/UIGF4GachaWindow.xaml
+++ b/src/Starward/Features/Gacha/UIGF/UIGF4GachaWindow.xaml
@@ -61,7 +61,7 @@
                     </StackPanel>
 
                     <TextBlock Grid.Row="1"
-                               Margin="508,8,0,0"
+                               Margin="296,8,0,0"
                                Foreground="{ThemeResource TextFillColorSecondaryBrush}"
                                Text="{x:Bind lang:Lang.GachaImportAndExportWindow_TheLastGachaPull}" />
 
@@ -73,10 +73,6 @@
                                    VerticalAlignment="Center"
                                    Foreground="{ThemeResource TextFillColorSecondaryBrush}"
                                    Text="Uid" />
-                        <TextBlock Width="200"
-                                   VerticalAlignment="Center"
-                                   Foreground="{ThemeResource TextFillColorSecondaryBrush}"
-                                   Text="{x:Bind lang:Lang.GachaImportAndExportWindow_ArchiveType}" />
                         <TextBlock Width="80"
                                    VerticalAlignment="Center"
                                    Foreground="{ThemeResource TextFillColorSecondaryBrush}"
@@ -108,9 +104,6 @@
                                     <TextBlock Width="100"
                                                VerticalAlignment="Center"
                                                Text="{x:Bind Uid}" />
-                                    <TextBlock Width="200"
-                                               VerticalAlignment="Center"
-                                               Text="{x:Bind ArchiveName}" />
                                     <TextBlock Width="80"
                                                VerticalAlignment="Center"
                                                Text="{x:Bind Count}" />
@@ -161,7 +154,7 @@
                                TextWrapping="Wrap" />
 
                     <TextBlock Grid.Row="2"
-                               Margin="508,8,0,0"
+                               Margin="296,8,0,0"
                                Foreground="{ThemeResource TextFillColorSecondaryBrush}"
                                Text="{x:Bind lang:Lang.GachaImportAndExportWindow_TheLastGachaPull}" />
 
@@ -173,10 +166,6 @@
                                    VerticalAlignment="Center"
                                    Foreground="{ThemeResource TextFillColorSecondaryBrush}"
                                    Text="Uid" />
-                        <TextBlock Width="200"
-                                   VerticalAlignment="Center"
-                                   Foreground="{ThemeResource TextFillColorSecondaryBrush}"
-                                   Text="{x:Bind lang:Lang.GachaImportAndExportWindow_ArchiveType}" />
                         <TextBlock Width="80"
                                    VerticalAlignment="Center"
                                    Foreground="{ThemeResource TextFillColorSecondaryBrush}"
@@ -215,7 +204,6 @@
                                     <Grid.ColumnDefinitions>
                                         <ColumnDefinition Width="36" />
                                         <ColumnDefinition Width="100" />
-                                        <ColumnDefinition Width="200" />
                                         <ColumnDefinition Width="80" />
                                         <ColumnDefinition Width="160" />
                                         <ColumnDefinition Width="200" />
@@ -233,36 +221,32 @@
                                                VerticalAlignment="Center"
                                                Text="{x:Bind Uid}" />
                                     <TextBlock Grid.Column="2"
-                                               Width="200"
-                                               VerticalAlignment="Center"
-                                               Text="{x:Bind ArchiveName}" />
-                                    <TextBlock Grid.Column="3"
                                                Width="80"
                                                VerticalAlignment="Center"
                                                Text="{x:Bind Count}" />
-                                    <TextBlock Grid.Column="4"
+                                    <TextBlock Grid.Column="3"
                                                Width="160"
                                                VerticalAlignment="Center"
                                                Text="{x:Bind LastItemTime.ToString('yyyy-MM-dd HH:mm:ss', x:Null)}" />
-                                    <TextBlock Grid.Column="5"
+                                    <TextBlock Grid.Column="4"
                                                Width="200"
                                                VerticalAlignment="Center"
                                                Text="{x:Bind LastItemName}" />
-                                    <NumberBox Grid.Column="6"
+                                    <NumberBox Grid.Column="5"
                                                Width="160"
                                                VerticalAlignment="Center"
                                                SpinButtonPlacementMode="Inline"
                                                Value="{x:Bind Timezone, Mode=TwoWay}" />
-                                    <TextBlock Grid.Column="7"
+                                    <TextBlock Grid.Column="6"
                                                Width="160"
                                                VerticalAlignment="Center"
                                                Text="{x:Bind LastItemTimeOffest.ToString('yyyy-MM-dd HH:mm:ss', x:Null)}" />
-                                    <TextBlock Grid.Column="8"
+                                    <TextBlock Grid.Column="7"
                                                VerticalAlignment="Center"
                                                Foreground="{ThemeResource SystemFillColorSuccessBrush}"
                                                Text="{x:Bind Result}"
                                                TextWrapping="Wrap" />
-                                    <TextBlock Grid.Column="8"
+                                    <TextBlock Grid.Column="7"
                                                VerticalAlignment="Center"
                                                Foreground="{ThemeResource SystemFillColorCriticalBrush}"
                                                Text="{x:Bind Error}"

--- a/src/Starward/Features/Gacha/UIGF/UIGF4GachaWindow.xaml
+++ b/src/Starward/Features/Gacha/UIGF/UIGF4GachaWindow.xaml
@@ -61,7 +61,7 @@
                     </StackPanel>
 
                     <TextBlock Grid.Row="1"
-                               Margin="296,8,0,0"
+                               Margin="448,8,0,0"
                                Foreground="{ThemeResource TextFillColorSecondaryBrush}"
                                Text="{x:Bind lang:Lang.GachaImportAndExportWindow_TheLastGachaPull}" />
 
@@ -161,7 +161,7 @@
                                TextWrapping="Wrap" />
 
                     <TextBlock Grid.Row="2"
-                               Margin="296,8,0,0"
+                               Margin="448,8,0,0"
                                Foreground="{ThemeResource TextFillColorSecondaryBrush}"
                                Text="{x:Bind lang:Lang.GachaImportAndExportWindow_TheLastGachaPull}" />
 

--- a/src/Starward/Features/Gacha/UIGF/UIGF4GachaWindow.xaml
+++ b/src/Starward/Features/Gacha/UIGF/UIGF4GachaWindow.xaml
@@ -61,7 +61,7 @@
                     </StackPanel>
 
                     <TextBlock Grid.Row="1"
-                               Margin="448,8,0,0"
+                               Margin="508,8,0,0"
                                Foreground="{ThemeResource TextFillColorSecondaryBrush}"
                                Text="{x:Bind lang:Lang.GachaImportAndExportWindow_TheLastGachaPull}" />
 
@@ -73,7 +73,7 @@
                                    VerticalAlignment="Center"
                                    Foreground="{ThemeResource TextFillColorSecondaryBrush}"
                                    Text="Uid" />
-                        <TextBlock Width="140"
+                        <TextBlock Width="200"
                                    VerticalAlignment="Center"
                                    Foreground="{ThemeResource TextFillColorSecondaryBrush}"
                                    Text="{x:Bind lang:Lang.GachaImportAndExportWindow_ArchiveType}" />
@@ -108,7 +108,7 @@
                                     <TextBlock Width="100"
                                                VerticalAlignment="Center"
                                                Text="{x:Bind Uid}" />
-                                    <TextBlock Width="140"
+                                    <TextBlock Width="200"
                                                VerticalAlignment="Center"
                                                Text="{x:Bind ArchiveName}" />
                                     <TextBlock Width="80"
@@ -161,7 +161,7 @@
                                TextWrapping="Wrap" />
 
                     <TextBlock Grid.Row="2"
-                               Margin="448,8,0,0"
+                               Margin="508,8,0,0"
                                Foreground="{ThemeResource TextFillColorSecondaryBrush}"
                                Text="{x:Bind lang:Lang.GachaImportAndExportWindow_TheLastGachaPull}" />
 
@@ -173,7 +173,7 @@
                                    VerticalAlignment="Center"
                                    Foreground="{ThemeResource TextFillColorSecondaryBrush}"
                                    Text="Uid" />
-                        <TextBlock Width="140"
+                        <TextBlock Width="200"
                                    VerticalAlignment="Center"
                                    Foreground="{ThemeResource TextFillColorSecondaryBrush}"
                                    Text="{x:Bind lang:Lang.GachaImportAndExportWindow_ArchiveType}" />
@@ -215,7 +215,7 @@
                                     <Grid.ColumnDefinitions>
                                         <ColumnDefinition Width="36" />
                                         <ColumnDefinition Width="100" />
-                                        <ColumnDefinition Width="140" />
+                                        <ColumnDefinition Width="200" />
                                         <ColumnDefinition Width="80" />
                                         <ColumnDefinition Width="160" />
                                         <ColumnDefinition Width="200" />
@@ -233,7 +233,7 @@
                                                VerticalAlignment="Center"
                                                Text="{x:Bind Uid}" />
                                     <TextBlock Grid.Column="2"
-                                               Width="140"
+                                               Width="200"
                                                VerticalAlignment="Center"
                                                Text="{x:Bind ArchiveName}" />
                                     <TextBlock Grid.Column="3"

--- a/src/Starward/Features/Gacha/UIGF/UIGF4GachaWindow.xaml
+++ b/src/Starward/Features/Gacha/UIGF/UIGF4GachaWindow.xaml
@@ -23,7 +23,7 @@
                    VerticalAlignment="Center"
                    Foreground="{ThemeResource TextFillColorSecondaryBrush}">
             <Run Text="{x:Bind lang:Lang.ToolboxSetting_GachaRecordsImportExport}" />
-            <Run Text="(UIGF v4.0)" />
+            <Run Text="(UIGF v4.2)" />
         </TextBlock>
 
 
@@ -73,6 +73,10 @@
                                    VerticalAlignment="Center"
                                    Foreground="{ThemeResource TextFillColorSecondaryBrush}"
                                    Text="Uid" />
+                        <TextBlock Width="140"
+                                   VerticalAlignment="Center"
+                                   Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                   Text="{x:Bind lang:Lang.GachaImportAndExportWindow_ArchiveType}" />
                         <TextBlock Width="80"
                                    VerticalAlignment="Center"
                                    Foreground="{ThemeResource TextFillColorSecondaryBrush}"
@@ -104,6 +108,9 @@
                                     <TextBlock Width="100"
                                                VerticalAlignment="Center"
                                                Text="{x:Bind Uid}" />
+                                    <TextBlock Width="140"
+                                               VerticalAlignment="Center"
+                                               Text="{x:Bind ArchiveName}" />
                                     <TextBlock Width="80"
                                                VerticalAlignment="Center"
                                                Text="{x:Bind Count}" />
@@ -166,6 +173,10 @@
                                    VerticalAlignment="Center"
                                    Foreground="{ThemeResource TextFillColorSecondaryBrush}"
                                    Text="Uid" />
+                        <TextBlock Width="140"
+                                   VerticalAlignment="Center"
+                                   Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                   Text="{x:Bind lang:Lang.GachaImportAndExportWindow_ArchiveType}" />
                         <TextBlock Width="80"
                                    VerticalAlignment="Center"
                                    Foreground="{ThemeResource TextFillColorSecondaryBrush}"
@@ -204,6 +215,7 @@
                                     <Grid.ColumnDefinitions>
                                         <ColumnDefinition Width="36" />
                                         <ColumnDefinition Width="100" />
+                                        <ColumnDefinition Width="140" />
                                         <ColumnDefinition Width="80" />
                                         <ColumnDefinition Width="160" />
                                         <ColumnDefinition Width="200" />
@@ -221,32 +233,36 @@
                                                VerticalAlignment="Center"
                                                Text="{x:Bind Uid}" />
                                     <TextBlock Grid.Column="2"
+                                               Width="140"
+                                               VerticalAlignment="Center"
+                                               Text="{x:Bind ArchiveName}" />
+                                    <TextBlock Grid.Column="3"
                                                Width="80"
                                                VerticalAlignment="Center"
                                                Text="{x:Bind Count}" />
-                                    <TextBlock Grid.Column="3"
+                                    <TextBlock Grid.Column="4"
                                                Width="160"
                                                VerticalAlignment="Center"
                                                Text="{x:Bind LastItemTime.ToString('yyyy-MM-dd HH:mm:ss', x:Null)}" />
-                                    <TextBlock Grid.Column="4"
+                                    <TextBlock Grid.Column="5"
                                                Width="200"
                                                VerticalAlignment="Center"
                                                Text="{x:Bind LastItemName}" />
-                                    <NumberBox Grid.Column="5"
+                                    <NumberBox Grid.Column="6"
                                                Width="160"
                                                VerticalAlignment="Center"
                                                SpinButtonPlacementMode="Inline"
                                                Value="{x:Bind Timezone, Mode=TwoWay}" />
-                                    <TextBlock Grid.Column="6"
+                                    <TextBlock Grid.Column="7"
                                                Width="160"
                                                VerticalAlignment="Center"
                                                Text="{x:Bind LastItemTimeOffest.ToString('yyyy-MM-dd HH:mm:ss', x:Null)}" />
-                                    <TextBlock Grid.Column="7"
+                                    <TextBlock Grid.Column="8"
                                                VerticalAlignment="Center"
                                                Foreground="{ThemeResource SystemFillColorSuccessBrush}"
                                                Text="{x:Bind Result}"
                                                TextWrapping="Wrap" />
-                                    <TextBlock Grid.Column="7"
+                                    <TextBlock Grid.Column="8"
                                                VerticalAlignment="Center"
                                                Foreground="{ThemeResource SystemFillColorCriticalBrush}"
                                                Text="{x:Bind Error}"

--- a/src/Starward/Features/Gacha/UIGF/UIGFGachaService.cs
+++ b/src/Starward/Features/Gacha/UIGF/UIGFGachaService.cs
@@ -201,7 +201,7 @@ internal class UIGFGachaService
         {
             Uid = uid,
             List = list.ToList(),
-            Lang = list.LastOrDefault()?.Lang ?? "",
+            Lang = list.LastOrDefault()?.Lang is { Length: > 0 } l ? l : null,
         };
         archive.Timezone = uid.ToString()[0] switch
         {
@@ -216,17 +216,24 @@ internal class UIGFGachaService
 
     /// <summary>
     /// 千星奇域，UIGF v4.2 的 hk4e_ugc 区段。
-    /// 记录本身没有 lang 字段，region 与 is_up 是标准未定义的扩展字段，随记录一并写出以便无损往返。
+    /// 记录本身没有 lang 字段，故从同一 Uid 的原神本体记录推导，再退回到抽卡语言设置；
+    /// 两者都拿不到时留 null 整个省略该字段，避免写出 enum 不允许的空字符串。
+    /// region 与 is_up 是标准未定义的扩展字段，随记录一并写出以便无损往返。
     /// </summary>
     private UIGF4GachaArchive<GenshinBeyondGachaItem> GetUIGFGachaArchiveForGenshinBeyond(long uid)
     {
         using var dapper = DatabaseService.CreateConnection();
         IEnumerable<GenshinBeyondGachaItem> list = dapper.Query<GenshinBeyondGachaItem>($"SELECT * FROM GenshinBeyondGachaItem WHERE Uid=@Uid ORDER BY Id;", new { Uid = uid });
+        string? lang = dapper.QueryFirstOrDefault<string?>($"SELECT Lang FROM GenshinGachaItem WHERE Uid=@Uid AND Lang IS NOT NULL AND Lang <> '' ORDER BY Id DESC LIMIT 1;", new { Uid = uid });
+        if (string.IsNullOrWhiteSpace(lang))
+        {
+            lang = AppConfig.GachaLanguage;
+        }
         UIGF4GachaArchive<GenshinBeyondGachaItem> archive = new()
         {
             Uid = uid,
             List = list.ToList(),
-            Lang = "",
+            Lang = string.IsNullOrWhiteSpace(lang) ? null : LanguageUtil.FilterLanguage(lang),
         };
         archive.Timezone = uid.ToString()[0] switch
         {
@@ -247,7 +254,7 @@ internal class UIGFGachaService
         {
             Uid = uid,
             List = list.ToList(),
-            Lang = list.LastOrDefault()?.Lang ?? "",
+            Lang = list.LastOrDefault()?.Lang is { Length: > 0 } l ? l : null,
         };
         archive.Timezone = uid.ToString()[0] switch
         {
@@ -268,7 +275,7 @@ internal class UIGFGachaService
         {
             Uid = uid,
             List = list.ToList(),
-            Lang = list.LastOrDefault()?.Lang ?? "",
+            Lang = list.LastOrDefault()?.Lang is { Length: > 0 } l ? l : null,
         };
         return archive;
     }

--- a/src/Starward/Features/Gacha/UIGF/UIGFGachaService.cs
+++ b/src/Starward/Features/Gacha/UIGF/UIGFGachaService.cs
@@ -89,7 +89,7 @@ internal class UIGFGachaService
             var display = new GachaUidArchiveDisplay
             {
                 Game = GameBiz.hk4e,
-                GameIcon = "ms-appx:///Assets/Image/icon_ys.jpg",
+                GameIcon = "ms-appx:///Assets/Image/icon_ys_ugc.jpg",
                 IsGenshinBeyond = true,
                 Uid = uid,
                 Count = count,
@@ -324,7 +324,7 @@ internal class UIGFGachaService
                 GachaUidArchiveDisplay archive = new()
                 {
                     Game = GameBiz.hk4e,
-                    GameIcon = "ms-appx:///Assets/Image/icon_ys.jpg",
+                    GameIcon = "ms-appx:///Assets/Image/icon_ys_ugc.jpg",
                     IsGenshinBeyond = true,
                     Uid = item.Uid,
                     hk4eUgcList = item.List,

--- a/src/Starward/Features/Gacha/UIGF/UIGFGachaService.cs
+++ b/src/Starward/Features/Gacha/UIGF/UIGFGachaService.cs
@@ -5,6 +5,7 @@ using Starward.Core.Gacha;
 using Starward.Core.Gacha.Genshin;
 using Starward.Core.Gacha.StarRail;
 using Starward.Core.Gacha.ZZZ;
+using Starward.Core.Localization;
 using Starward.Features.Database;
 using System;
 using System.Collections.Generic;
@@ -39,6 +40,7 @@ internal class UIGFGachaService
         List<GachaUidArchiveDisplay> result =
         [
             .. GetLocalGachaArchivesForGenshin(),
+            .. GetLocalGachaArchivesForGenshinBeyond(),
             .. GetLocalGachaArchivesForStarRail(),
             .. GetLocalGachaArchivesForZZZ(),
         ];
@@ -64,6 +66,35 @@ internal class UIGFGachaService
                 Count = count,
                 LastItemGachaType = ((GenshinGachaType)lastItem.GachaType).ToLocalization(),
                 LastItemName = lastItem.Name,
+                LastItemTime = lastItem.Time
+            };
+            result.Add(display);
+        }
+        return result;
+    }
+
+
+    /// <summary>
+    /// 千星奇域，与原神本体共用 Uid，单独成行
+    /// </summary>
+    private List<GachaUidArchiveDisplay> GetLocalGachaArchivesForGenshinBeyond()
+    {
+        using var dapper = DatabaseService.CreateConnection();
+        List<GachaUidArchiveDisplay> result = new();
+        var uidList = dapper.Query<long>($"SELECT DISTINCT Uid FROM GenshinBeyondGachaItem;");
+        foreach (long uid in uidList)
+        {
+            int count = dapper.QueryFirstOrDefault<int>($"SELECT COUNT(*) FROM GenshinBeyondGachaItem WHERE Uid=@Uid;", new { Uid = uid });
+            GenshinBeyondGachaItem lastItem = dapper.QueryFirst<GenshinBeyondGachaItem>($"SELECT * FROM GenshinBeyondGachaItem WHERE Uid=@Uid ORDER BY Time DESC LIMIT 1;", new { Uid = uid });
+            var display = new GachaUidArchiveDisplay
+            {
+                Game = GameBiz.hk4e,
+                GameIcon = "ms-appx:///Assets/Image/icon_ys.jpg",
+                IsGenshinBeyond = true,
+                Uid = uid,
+                Count = count,
+                LastItemGachaType = lastItem.OpGachaType is 1000 ? CoreLang.GachaType_StandardOde : CoreLang.GachaType_EventOde,
+                LastItemName = lastItem.ItemName,
                 LastItemTime = lastItem.Time
             };
             result.Add(display);
@@ -130,7 +161,14 @@ internal class UIGFGachaService
         {
             if (archive.Game == GameBiz.hk4e)
             {
-                uigfObj.hk4eGachaArchives!.Add(GetUIGFGachaArchiveForGenshin(archive.Uid));
+                if (archive.IsGenshinBeyond)
+                {
+                    uigfObj.hk4eUgcGachaArchives!.Add(GetUIGFGachaArchiveForGenshinBeyond(archive.Uid));
+                }
+                else
+                {
+                    uigfObj.hk4eGachaArchives!.Add(GetUIGFGachaArchiveForGenshin(archive.Uid));
+                }
             }
             if (archive.Game == GameBiz.hkrpg)
             {
@@ -164,6 +202,31 @@ internal class UIGFGachaService
             Uid = uid,
             List = list.ToList(),
             Lang = list.LastOrDefault()?.Lang ?? "",
+        };
+        archive.Timezone = uid.ToString()[0] switch
+        {
+            '6' => -5,
+            '7' => 1,
+            _ => 8,
+        };
+        return archive;
+    }
+
+
+
+    /// <summary>
+    /// 千星奇域，UIGF v4.2 的 hk4e_ugc 区段。
+    /// 记录本身没有 lang 字段，region 与 is_up 是标准未定义的扩展字段，随记录一并写出以便无损往返。
+    /// </summary>
+    private UIGF4GachaArchive<GenshinBeyondGachaItem> GetUIGFGachaArchiveForGenshinBeyond(long uid)
+    {
+        using var dapper = DatabaseService.CreateConnection();
+        IEnumerable<GenshinBeyondGachaItem> list = dapper.Query<GenshinBeyondGachaItem>($"SELECT * FROM GenshinBeyondGachaItem WHERE Uid=@Uid ORDER BY Id;", new { Uid = uid });
+        UIGF4GachaArchive<GenshinBeyondGachaItem> archive = new()
+        {
+            Uid = uid,
+            List = list.ToList(),
+            Lang = "",
         };
         archive.Timezone = uid.ToString()[0] switch
         {
@@ -246,6 +309,27 @@ internal class UIGFGachaService
                 list.Add(archive);
             }
         }
+        foreach (UIGF4GachaArchive<GenshinBeyondGachaItem> item in uigf4Obj.hk4eUgcGachaArchives ?? [])
+        {
+            if (item.List.Count > 0)
+            {
+                GenshinBeyondGachaItem last = item.List.OrderBy(x => x.Id).Last();
+                GachaUidArchiveDisplay archive = new()
+                {
+                    Game = GameBiz.hk4e,
+                    GameIcon = "ms-appx:///Assets/Image/icon_ys.jpg",
+                    IsGenshinBeyond = true,
+                    Uid = item.Uid,
+                    hk4eUgcList = item.List,
+                    Count = item.List.Count,
+                    LastItemGachaType = last.OpGachaType is 1000 ? CoreLang.GachaType_StandardOde : CoreLang.GachaType_EventOde,
+                    LastItemName = last.ItemName,
+                    LastItemTime = last.Time,
+                    LastItemTimeOffest = last.Time,
+                };
+                list.Add(archive);
+            }
+        }
         foreach (UIGF4GachaArchive<StarRailGachaItem> item in uigf4Obj.hkrpgGachaArchives ?? [])
         {
             if (item.List.Count > 0)
@@ -303,7 +387,14 @@ internal class UIGFGachaService
                 archive.Error = null;
                 if (archive.Game == GameBiz.hk4e)
                 {
-                    ImportForGenshin(archive);
+                    if (archive.IsGenshinBeyond)
+                    {
+                        ImportForGenshinBeyond(archive);
+                    }
+                    else
+                    {
+                        ImportForGenshin(archive);
+                    }
                 }
                 if (archive.Game == GameBiz.hkrpg)
                 {
@@ -375,6 +466,72 @@ internal class UIGFGachaService
             """, list, t);
         t.Commit();
         _logger.LogInformation("Imported {count} gacha records for {game}.", affect, archive.Game);
+        archive.Result = noName ? Lang.UIGFGachaService_ImportSuccessfulButNoRecordItemName : Lang.UIGFGachaService_ImportSuccessful;
+    }
+
+
+
+    /// <summary>
+    /// 千星奇域。region 与 is_up 是 UIGF 未定义的扩展字段，来自其他应用的文件可能没有，缺失时留空。
+    /// </summary>
+    private void ImportForGenshinBeyond(GachaUidArchiveDisplay archive)
+    {
+        List<GenshinBeyondGachaItem> list = new();
+        DateTime TIME = new DateTime(2025, 10, 1);
+        bool noName = false;
+        foreach (GenshinBeyondGachaItem item in archive.hk4eUgcList ?? [])
+        {
+            if (item.Id == 0)
+            {
+                throw new UIGF4ImportException(archive.Game, archive.Uid, string.Format(Lang.UIGFGachaService_0FieldIsMissingInAGachaRecord, "id"));
+            }
+            if (item.ItemId == 0)
+            {
+                throw new UIGF4ImportException(archive.Game, archive.Uid, string.Format(Lang.UIGFGachaService_0FieldIsMissingInAGachaRecord, "item_id"));
+            }
+            if (item.OpGachaType == 0)
+            {
+                throw new UIGF4ImportException(archive.Game, archive.Uid, string.Format(Lang.UIGFGachaService_0FieldIsMissingInAGachaRecord, "op_gacha_type"));
+            }
+            if (item.Time < TIME)
+            {
+                throw new UIGF4ImportException(archive.Game, archive.Uid, string.Format(Lang.UIGFGachaService_0FieldIsMissingInAGachaRecord, "time"));
+            }
+            if (item.RankType == 0)
+            {
+                throw new UIGF4ImportException(archive.Game, archive.Uid, string.Format(Lang.UIGFGachaService_0FieldIsMissingInAGachaRecord, "rank_type"));
+            }
+            if (string.IsNullOrWhiteSpace(item.ItemName))
+            {
+                noName = true;
+            }
+            if (item.Uid != 0 && item.Uid != archive.Uid)
+            {
+                throw new UIGF4ImportException(archive.Game, archive.Uid, string.Format(Lang.UIGFGachaService_UidMismatchDetectedExpected0ButFound1, archive.Uid, item.Uid));
+            }
+            list.Add(new GenshinBeyondGachaItem
+            {
+                Uid = archive.Uid,
+                Id = item.Id,
+                Region = item.Region,
+                OpGachaType = item.OpGachaType,
+                ScheduleId = item.ScheduleId,
+                ItemType = item.ItemType,
+                ItemId = item.ItemId,
+                ItemName = item.ItemName,
+                RankType = item.RankType,
+                IsUp = item.IsUp,
+                Time = item.Time.AddHours(archive.Timezone),
+            });
+        }
+        using var dapper = DatabaseService.CreateConnection();
+        using var t = dapper.BeginTransaction();
+        var affect = dapper.Execute("""
+            INSERT OR REPLACE INTO GenshinBeyondGachaItem (Uid, Id, Region, OpGachaType, ScheduleId, ItemType, ItemId, ItemName, RankType, IsUp, Time)
+            VALUES (@Uid, @Id, @Region, @OpGachaType, @ScheduleId, @ItemType, @ItemId, @ItemName, @RankType, @IsUp, @Time);
+            """, list, t);
+        t.Commit();
+        _logger.LogInformation("Imported {count} gacha records for {game} beyond.", affect, archive.Game);
         archive.Result = noName ? Lang.UIGFGachaService_ImportSuccessfulButNoRecordItemName : Lang.UIGFGachaService_ImportSuccessful;
     }
 

--- a/src/Starward/Features/Setting/ToolboxSetting.xaml.cs
+++ b/src/Starward/Features/Setting/ToolboxSetting.xaml.cs
@@ -31,7 +31,7 @@ public sealed partial class ToolboxSetting : PageBase
                             null,
                             nameof(UIGF4GachaWindow),
                             nameof(Lang.ToolboxSetting_GachaRecordsImportExport),
-                            ""){ Description="UIGF v4.0" },
+                            ""){ Description="UIGF v4.2" },
             new ToolboxItem(null,
                             "ms-appx:///Assets/Image/GachaTicket2Big.png",
                             nameof(ZZZGachaInfoWindow),


### PR DESCRIPTION
# 背景

项目此前实现的是 UIGF v4.0。UIGF 标准已迭代两版：

- **v4.1**（2025-08）新增星铁联动跃迁卡池类型 `21`/`22`
- **v4.2**（2026-01）新增千星奇域区段 `hk4e_ugc`

其中 v4.1 的缺口是一处**已存在的标注错误**：`StarRailGachaClient` 的 `QueryGachaTypes` 早在 2025-07 就包含了 `21`/`22`，导出文件实际已是 v4.1 规格，但 `info.version` 仍写 `v4.0`——而 v4.0 的 `hkrpg.gacha_type` 枚举只允许 `1/2/11/12`。只要用户有联动池记录，导出的文件就无法通过它自己声明的 schema 校验。

# 改动

**数据模型**

- `UIGF4File` 新增 `hk4e_ugc` 区段，`info.version` 升至 `v4.2`
- 解除 `UIGF4GachaArchive<T>` 的 `where T : GachaLogItem` 约束（千星奇域记录类不继承 `GachaLogItem`，且该约束在类体内未被使用）
- 复用现有的 `GenshinBeyondGachaItem`——其 JSON 属性名与标准的 `hk4e_ugc` 字段已完全对齐，未新建 DTO

**导入导出**

- `UIGFGachaService` 新增千星奇域的档案枚举、导出、导入三条链路
- 千星奇域与原神本体共用 UID，通过 `IsGenshinBeyond` 标记在导出列表中独立成行，可单独勾选
- `region` / `is_up` 是标准未定义的扩展字段，随记录一并写出以保证 Starward 之间无损往返；标准未禁止额外字段，其他应用会自动忽略

**UI**

- 跃迁记录页浮窗：`Json` → `UIGF v3.0`，`从 JSON 导入` → `从 UIGF v3.0 导入`，`UIGF v4.0` → `UIGF v4.2` 并以分割线隔开，明确两套互不兼容的导出逻辑
- 原神页面导出 UIGF v3.0 时，若当前 UID 存在千星奇域记录，弹窗告知该部分数据不会被导出，提供【继续】/【取消】，默认焦点在【取消】
- UIGF v4.2 窗口的导出/导入列表新增「档案类型」列

# 说明

- 千星奇域导入沿用现有校验风格：`id`/`item_id`/`op_gacha_type`/`time`/`rank_type` 缺失抛 `UIGF4ImportException`，`item_name` 缺失走软提示
- 本次仅补齐 `Lang.resx` 与 `Lang.zh-CN.resx`，其余语种交由 Crowdin 同步
- 标准中 `hk4e_ugc` 的 `properties`/`required` 被写在数组层级而非 `items` 内，对校验器实际失效——这是 UIGF 侧的 schema 书写问题，本实现按语义字段对齐，不依赖 schema.uigf.org 校验该区段

# 测试

- UI 更新
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/4cb467f7-ecf1-43ab-876a-c09f7003c5ff" />
<img width="1424" height="732" alt="image" src="https://github.com/user-attachments/assets/e9635037-ea87-45b7-8b77-f1eaf67b4298" />

- UIGF v4.2 验证通过
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/5f4de988-1905-4015-9ca9-f60d94c98e5b" />

~本人无千星奇域抽卡记录，且原神早已退坑，待寻找有抽卡记录的 UID 进行千星奇域验证~

~代码由 Claude Opus 5 生成，本地验证通过，[GitHub Action](https://github.com/WindDrift/Starward/actions/runs/30198549090) 构建通过。~