### PR TITLE
update adversity mode of zzz deadly assault

### DIFF
--- a/src/Starward.Core/GameRecord/HoyolabClient.cs
+++ b/src/Starward.Core/GameRecord/HoyolabClient.cs
@@ -804,7 +804,7 @@ public class HoyolabClient : GameRecordClient
     /// <returns></returns>
     public override async Task<DeadlyAssaultInfo> GetDeadlyAssaultInfoAsync(GameRecordRole role, int schedule, CancellationToken cancellationToken = default)
     {
-        var url = $"https://sg-public-api.hoyolab.com/event/game_record_zzz/api/zzz/mem_detail?schedule_type={schedule}&region={role.Region}&uid={role.Uid}";
+        var url = $"https://sg-public-api.hoyolab.com/event/game_record_zzz/api/zzz/hadal_mem_detail_v2?schedule_type={schedule}&region={role.Region}&uid={role.Uid}";
         var request = new HttpRequestMessage(HttpMethod.Get, url);
         request.Headers.Add(Cookie, role.Cookie);
         request.Headers.Add(DS, CreateSecret2(url));

--- a/src/Starward.Core/GameRecord/HyperionClient.cs
+++ b/src/Starward.Core/GameRecord/HyperionClient.cs
@@ -868,7 +868,7 @@ public class HyperionClient : GameRecordClient
     /// <returns></returns>
     public override async Task<DeadlyAssaultInfo> GetDeadlyAssaultInfoAsync(GameRecordRole role, int schedule, CancellationToken cancellationToken = default)
     {
-        var url = $"https://api-takumi-record.mihoyo.com/event/game_record_zzz/api/zzz/mem_detail?schedule_type={schedule}&region={role.Region}&uid={role.Uid}";
+        var url = $"https://api-takumi-record.mihoyo.com/event/game_record_zzz/api/zzz/hadal_mem_detail_v2?schedule_type={schedule}&region={role.Region}&uid={role.Uid}";
         var request = new HttpRequestMessage(HttpMethod.Get, url);
         request.Headers.Add(Cookie, role.Cookie);
         request.Headers.Add(DS, CreateSecret2(url));

--- a/src/Starward.Core/GameRecord/ZZZ/DeadlyAssault/DeadlyAssaultInfo.cs
+++ b/src/Starward.Core/GameRecord/ZZZ/DeadlyAssault/DeadlyAssaultInfo.cs
@@ -36,6 +36,9 @@ public class DeadlyAssaultInfo
     [JsonPropertyName("rank_percent")]
     public int RankPercent { get; set; }
 
+    /// <summary>
+    /// 试炼模式节点
+    /// </summary>
     [JsonPropertyName("list")]
     public List<DeadlyAssaultNode> AllNodes { get; set; }
 
@@ -66,6 +69,37 @@ public class DeadlyAssaultInfo
     /// </summary>
     [JsonPropertyName("total_star")]
     public int TotalStar { get; set; }
+
+
+    /// <summary>
+    /// 是否有绝境模式数据
+    /// </summary>
+    [JsonPropertyName("has_hard")]
+    public bool HasHard { get; set; }
+
+    /// <summary>
+    /// 绝境模式节点
+    /// </summary>
+    [JsonPropertyName("hard_list")]
+    public List<DeadlyAssaultNode> HardNodes { get; set; }
+
+    /// <summary>
+    /// 绝境模式当前排名，以0.01%为单位
+    /// </summary>
+    [JsonPropertyName("hard_rank_percent")]
+    public int HardRankPercent { get; set; }
+
+    /// <summary>
+    /// 绝境模式总分
+    /// </summary>
+    [JsonIgnore]
+    public int HardTotalScore { get; set; }
+
+    /// <summary>
+    /// 绝境模式总星数
+    /// </summary>
+    [JsonIgnore]
+    public int HardTotalStar { get; set; }
 
 
     [JsonExtensionData]

--- a/src/Starward.Language/Lang.Designer.cs
+++ b/src/Starward.Language/Lang.Designer.cs
@@ -1133,6 +1133,15 @@ namespace Starward.Language {
         }
         
         /// <summary>
+        ///   查找类似 Adversity Mode 的本地化字符串。
+        /// </summary>
+        public static string DeadlyAssaultPage_AdversityMode {
+            get {
+                return ResourceManager.GetString("DeadlyAssaultPage_AdversityMode", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   查找类似 Global Top 的本地化字符串。
         /// </summary>
         public static string DeadlyAssaultPage_GlobalTopPercent {

--- a/src/Starward.Language/Lang.Designer.cs
+++ b/src/Starward.Language/Lang.Designer.cs
@@ -1151,6 +1151,15 @@ namespace Starward.Language {
         }
         
         /// <summary>
+        ///   查找类似 Trial Mode 的本地化字符串。
+        /// </summary>
+        public static string DeadlyAssaultPage_TrialMode {
+            get {
+                return ResourceManager.GetString("DeadlyAssaultPage_TrialMode", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   查找类似 Warning: The selected time period includes gacha records from more than 6 months ago, which cannot be retrieved after deleting. 的本地化字符串。
         /// </summary>
         public static string DeleteGachaLogDialog_6MonthsDeletingWarning {

--- a/src/Starward.Language/Lang.de-DE.resx
+++ b/src/Starward.Language/Lang.de-DE.resx
@@ -2742,4 +2742,7 @@ Sie sind herzlich eingeladen, die exportierten Daten an das folgende Repository 
   <data name="DeadlyAssaultPage_TrialMode" xml:space="preserve">
     <value>Testmodus</value>
   </data>
+  <data name="DeadlyAssaultPage_AdversityMode" xml:space="preserve">
+    <value>Adversity-Modus</value>
+  </data>
 </root>

--- a/src/Starward.Language/Lang.de-DE.resx
+++ b/src/Starward.Language/Lang.de-DE.resx
@@ -2739,4 +2739,7 @@ Sie sind herzlich eingeladen, die exportierten Daten an das folgende Repository 
   <data name="DailyNoteButton_StarRail_AccumulatedPoints" xml:space="preserve">
     <value>Angesammelte Punkte</value>
   </data>
+  <data name="DeadlyAssaultPage_TrialMode" xml:space="preserve">
+    <value>Testmodus</value>
+  </data>
 </root>

--- a/src/Starward.Language/Lang.es-ES.resx
+++ b/src/Starward.Language/Lang.es-ES.resx
@@ -2744,4 +2744,7 @@ Puede enviar los datos exportados al siguiente repositorio:</value>
   <data name="DeadlyAssaultPage_TrialMode" xml:space="preserve">
     <value>Modo de prueba</value>
   </data>
+  <data name="DeadlyAssaultPage_AdversityMode" xml:space="preserve">
+    <value>Modo adversidad</value>
+  </data>
 </root>

--- a/src/Starward.Language/Lang.es-ES.resx
+++ b/src/Starward.Language/Lang.es-ES.resx
@@ -2741,4 +2741,7 @@ Puede enviar los datos exportados al siguiente repositorio:</value>
   <data name="DailyNoteButton_StarRail_AccumulatedPoints" xml:space="preserve">
     <value>Puntos acumulados</value>
   </data>
+  <data name="DeadlyAssaultPage_TrialMode" xml:space="preserve">
+    <value>Modo de prueba</value>
+  </data>
 </root>

--- a/src/Starward.Language/Lang.it-IT.resx
+++ b/src/Starward.Language/Lang.it-IT.resx
@@ -2741,4 +2741,7 @@ Sei invitato a inviare i dati esportati al seguente repository:</value>
   <data name="DailyNoteButton_StarRail_AccumulatedPoints" xml:space="preserve">
     <value>Punti accumulati</value>
   </data>
+  <data name="DeadlyAssaultPage_TrialMode" xml:space="preserve">
+    <value>Modalità prova</value>
+  </data>
 </root>

--- a/src/Starward.Language/Lang.it-IT.resx
+++ b/src/Starward.Language/Lang.it-IT.resx
@@ -2744,4 +2744,7 @@ Sei invitato a inviare i dati esportati al seguente repository:</value>
   <data name="DeadlyAssaultPage_TrialMode" xml:space="preserve">
     <value>Modalità prova</value>
   </data>
+  <data name="DeadlyAssaultPage_AdversityMode" xml:space="preserve">
+    <value>Modalità avversità</value>
+  </data>
 </root>

--- a/src/Starward.Language/Lang.ja-JP.resx
+++ b/src/Starward.Language/Lang.ja-JP.resx
@@ -2743,4 +2743,7 @@
   <data name="DeadlyAssaultPage_TrialMode" xml:space="preserve">
     <value>試練モード</value>
   </data>
+  <data name="DeadlyAssaultPage_AdversityMode" xml:space="preserve">
+    <value>逆境モード</value>
+  </data>
 </root>

--- a/src/Starward.Language/Lang.ja-JP.resx
+++ b/src/Starward.Language/Lang.ja-JP.resx
@@ -2740,4 +2740,7 @@
   <data name="DailyNoteButton_StarRail_AccumulatedPoints" xml:space="preserve">
     <value>累積ポイント</value>
   </data>
+  <data name="DeadlyAssaultPage_TrialMode" xml:space="preserve">
+    <value>試練モード</value>
+  </data>
 </root>

--- a/src/Starward.Language/Lang.ko-KR.resx
+++ b/src/Starward.Language/Lang.ko-KR.resx
@@ -2741,4 +2741,7 @@
   <data name="DailyNoteButton_StarRail_AccumulatedPoints" xml:space="preserve">
     <value>누적 포인트</value>
   </data>
+  <data name="DeadlyAssaultPage_TrialMode" xml:space="preserve">
+    <value>트라이얼 모드</value>
+  </data>
 </root>

--- a/src/Starward.Language/Lang.ko-KR.resx
+++ b/src/Starward.Language/Lang.ko-KR.resx
@@ -2744,4 +2744,7 @@
   <data name="DeadlyAssaultPage_TrialMode" xml:space="preserve">
     <value>트라이얼 모드</value>
   </data>
+  <data name="DeadlyAssaultPage_AdversityMode" xml:space="preserve">
+    <value>역경 모드</value>
+  </data>
 </root>

--- a/src/Starward.Language/Lang.resx
+++ b/src/Starward.Language/Lang.resx
@@ -2741,4 +2741,7 @@ You are welcome to submit the exported data to the following repository:</value>
   <data name="DailyNoteButton_StarRail_AccumulatedPoints" xml:space="preserve">
     <value>Accumulated Points</value>
   </data>
+  <data name="DeadlyAssaultPage_TrialMode" xml:space="preserve">
+    <value>Trial Mode</value>
+  </data>
 </root>

--- a/src/Starward.Language/Lang.resx
+++ b/src/Starward.Language/Lang.resx
@@ -2744,4 +2744,7 @@ You are welcome to submit the exported data to the following repository:</value>
   <data name="DeadlyAssaultPage_TrialMode" xml:space="preserve">
     <value>Trial Mode</value>
   </data>
+  <data name="DeadlyAssaultPage_AdversityMode" xml:space="preserve">
+    <value>Adversity Mode</value>
+  </data>
 </root>

--- a/src/Starward.Language/Lang.ru-RU.resx
+++ b/src/Starward.Language/Lang.ru-RU.resx
@@ -2761,4 +2761,7 @@ ChatGPT может допускать ошибки. Проверьте важн�
   <data name="DailyNoteButton_StarRail_AccumulatedPoints" xml:space="preserve">
     <value>Накопленные очки</value>
   </data>
+  <data name="DeadlyAssaultPage_TrialMode" xml:space="preserve">
+    <value>Испытательный режим</value>
+  </data>
 </root>

--- a/src/Starward.Language/Lang.ru-RU.resx
+++ b/src/Starward.Language/Lang.ru-RU.resx
@@ -2764,4 +2764,7 @@ ChatGPT может допускать ошибки. Проверьте важн�
   <data name="DeadlyAssaultPage_TrialMode" xml:space="preserve">
     <value>Испытательный режим</value>
   </data>
+  <data name="DeadlyAssaultPage_AdversityMode" xml:space="preserve">
+    <value>Режим невзгод</value>
+  </data>
 </root>

--- a/src/Starward.Language/Lang.th-TH.resx
+++ b/src/Starward.Language/Lang.th-TH.resx
@@ -2738,4 +2738,7 @@
   <data name="DeadlyAssaultPage_TrialMode" xml:space="preserve">
     <value>โหมดทดลอง</value>
   </data>
+  <data name="DeadlyAssaultPage_AdversityMode" xml:space="preserve">
+    <value>โหมดวิกฤต</value>
+  </data>
 </root>

--- a/src/Starward.Language/Lang.th-TH.resx
+++ b/src/Starward.Language/Lang.th-TH.resx
@@ -2735,4 +2735,7 @@
   <data name="DailyNoteButton_StarRail_AccumulatedPoints" xml:space="preserve">
     <value>คะแนนสะสม</value>
   </data>
+  <data name="DeadlyAssaultPage_TrialMode" xml:space="preserve">
+    <value>โหมดทดลอง</value>
+  </data>
 </root>

--- a/src/Starward.Language/Lang.vi-VN.resx
+++ b/src/Starward.Language/Lang.vi-VN.resx
@@ -2738,4 +2738,7 @@ Bạn có chấp nhận rủi ro và tiếp tục?</value>
   <data name="DailyNoteButton_StarRail_AccumulatedPoints" xml:space="preserve">
     <value>Điểm tích lũy</value>
   </data>
+  <data name="DeadlyAssaultPage_TrialMode" xml:space="preserve">
+    <value>Chế độ thử nghiệm</value>
+  </data>
 </root>

--- a/src/Starward.Language/Lang.vi-VN.resx
+++ b/src/Starward.Language/Lang.vi-VN.resx
@@ -2741,4 +2741,7 @@ Bạn có chấp nhận rủi ro và tiếp tục?</value>
   <data name="DeadlyAssaultPage_TrialMode" xml:space="preserve">
     <value>Chế độ thử nghiệm</value>
   </data>
+  <data name="DeadlyAssaultPage_AdversityMode" xml:space="preserve">
+    <value>Chế độ nghịch cảnh</value>
+  </data>
 </root>

--- a/src/Starward.Language/Lang.zh-CN.resx
+++ b/src/Starward.Language/Lang.zh-CN.resx
@@ -2744,4 +2744,7 @@
   <data name="DeadlyAssaultPage_TrialMode" xml:space="preserve">
     <value>试炼模式</value>
   </data>
+  <data name="DeadlyAssaultPage_AdversityMode" xml:space="preserve">
+    <value>绝境模式</value>
+  </data>
 </root>

--- a/src/Starward.Language/Lang.zh-CN.resx
+++ b/src/Starward.Language/Lang.zh-CN.resx
@@ -2741,4 +2741,7 @@
   <data name="DailyNoteButton_StarRail_AccumulatedPoints" xml:space="preserve">
     <value>周期积分</value>
   </data>
+  <data name="DeadlyAssaultPage_TrialMode" xml:space="preserve">
+    <value>试炼模式</value>
+  </data>
 </root>

--- a/src/Starward.Language/Lang.zh-HK.resx
+++ b/src/Starward.Language/Lang.zh-HK.resx
@@ -2740,4 +2740,7 @@
   <data name="DailyNoteButton_StarRail_AccumulatedPoints" xml:space="preserve">
     <value>週期積分</value>
   </data>
+  <data name="DeadlyAssaultPage_TrialMode" xml:space="preserve">
+    <value>試煉模式</value>
+  </data>
 </root>

--- a/src/Starward.Language/Lang.zh-HK.resx
+++ b/src/Starward.Language/Lang.zh-HK.resx
@@ -2743,4 +2743,7 @@
   <data name="DeadlyAssaultPage_TrialMode" xml:space="preserve">
     <value>試煉模式</value>
   </data>
+  <data name="DeadlyAssaultPage_AdversityMode" xml:space="preserve">
+    <value>絕境模式</value>
+  </data>
 </root>

--- a/src/Starward.Language/Lang.zh-TW.resx
+++ b/src/Starward.Language/Lang.zh-TW.resx
@@ -2741,4 +2741,7 @@
   <data name="DailyNoteButton_StarRail_AccumulatedPoints" xml:space="preserve">
     <value>週期積分</value>
   </data>
+  <data name="DeadlyAssaultPage_TrialMode" xml:space="preserve">
+    <value>試煉模式</value>
+  </data>
 </root>

--- a/src/Starward.Language/Lang.zh-TW.resx
+++ b/src/Starward.Language/Lang.zh-TW.resx
@@ -2744,4 +2744,7 @@
   <data name="DeadlyAssaultPage_TrialMode" xml:space="preserve">
     <value>試煉模式</value>
   </data>
+  <data name="DeadlyAssaultPage_AdversityMode" xml:space="preserve">
+    <value>絕境模式</value>
+  </data>
 </root>

--- a/src/Starward/Features/Database/DatabaseService.cs
+++ b/src/Starward/Features/Database/DatabaseService.cs
@@ -256,7 +256,8 @@ internal static class DatabaseService
         Sql_v16,
         Sql_v17,
         Sql_v18,
-        Sql_v19
+        Sql_v19,
+        Sql_v20
     ];
 
 
@@ -1021,6 +1022,17 @@ internal static class DatabaseService
         ALTER TABLE StarRailForgottenHallInfo ADD COLUMN ExtraStarNum INTEGER DEFAULT 0 NOT NULL;
 
         PRAGMA USER_VERSION = 19;
+        COMMIT TRANSACTION;
+        """;
+
+    private const string Sql_v20 = """
+        BEGIN TRANSACTION;
+
+        ALTER TABLE ZZZDeadlyAssaultInfo ADD COLUMN HasHard INTEGER DEFAULT 0 NOT NULL;
+        ALTER TABLE ZZZDeadlyAssaultInfo ADD COLUMN HardTotalScore INTEGER DEFAULT 0 NOT NULL;
+        ALTER TABLE ZZZDeadlyAssaultInfo ADD COLUMN HardTotalStar INTEGER DEFAULT 0 NOT NULL;
+
+        PRAGMA USER_VERSION = 20;
         COMMIT TRANSACTION;
         """;
 

--- a/src/Starward/Features/GameRecord/GameRecordService.cs
+++ b/src/Starward/Features/GameRecord/GameRecordService.cs
@@ -1114,13 +1114,18 @@ internal class GameRecordService
             info.RankPercent,
             info.TotalScore,
             info.TotalStar,
+            info.HasHard,
+            HardTotalScore = info.HardNodes?.Sum(x => x.Score) ?? 0,
+            HardTotalStar = info.HardNodes?.Sum(x => x.Star) ?? 0,
             Value = JsonSerializer.Serialize(info, AppConfig.JsonSerializerOptions),
         };
         using var dapper = DatabaseService.CreateConnection();
         dapper.Execute("""
-            INSERT OR REPLACE INTO ZZZDeadlyAssaultInfo (Uid, ZoneId, StartTime, EndTime, HasData, RankPercent, TotalScore, TotalStar, Value)
-            VALUES (@Uid, @ZoneId, @StartTime, @EndTime, @HasData, @RankPercent, @TotalScore, @TotalStar, @Value);
+            INSERT OR REPLACE INTO ZZZDeadlyAssaultInfo (Uid, ZoneId, StartTime, EndTime, HasData, RankPercent, TotalScore, TotalStar, HasHard, HardTotalScore, HardTotalStar, Value)
+            VALUES (@Uid, @ZoneId, @StartTime, @EndTime, @HasData, @RankPercent, @TotalScore, @TotalStar, @HasHard, @HardTotalScore, @HardTotalStar, @Value);
             """, obj);
+        info.HardTotalScore = info.HardNodes?.Sum(x => x.Score) ?? 0;
+        info.HardTotalStar = info.HardNodes?.Sum(x => x.Star) ?? 0;
         return info;
     }
 
@@ -1134,7 +1139,7 @@ internal class GameRecordService
         }
         using var dapper = DatabaseService.CreateConnection();
         var list = dapper.Query<DeadlyAssaultInfo>("""
-            SELECT Uid, ZoneId, StartTime, EndTime, HasData, RankPercent, TotalScore, TotalStar FROM ZZZDeadlyAssaultInfo WHERE Uid = @Uid ORDER BY ZoneId DESC;
+            SELECT Uid, ZoneId, StartTime, EndTime, HasData, RankPercent, TotalScore, TotalStar, HasHard, HardTotalScore, HardTotalStar FROM ZZZDeadlyAssaultInfo WHERE Uid = @Uid ORDER BY ZoneId DESC;
             """, new { role.Uid });
         return list.ToList();
     }
@@ -1151,7 +1156,13 @@ internal class GameRecordService
         {
             return null;
         }
-        return JsonSerializer.Deserialize<DeadlyAssaultInfo>(value);
+        var info = JsonSerializer.Deserialize<DeadlyAssaultInfo>(value);
+        if (info is not null)
+        {
+            info.HardTotalScore = info.HardNodes?.Sum(x => x.Score) ?? 0;
+            info.HardTotalStar = info.HardNodes?.Sum(x => x.Star) ?? 0;
+        }
+        return info;
     }
 
 

--- a/src/Starward/Features/GameRecord/ZZZ/DeadlyAssaultPage.xaml
+++ b/src/Starward/Features/GameRecord/ZZZ/DeadlyAssaultPage.xaml
@@ -20,6 +20,7 @@
     <Page.Resources>
         <BitmapImage x:Key="StarIconLight" UriSource="ms-appx:///Assets/Image/star-icon-light.5a286c6d.png" />
         <BitmapImage x:Key="StarIconDark" UriSource="ms-appx:///Assets/Image/star-icon-dark.28cb98f1.png" />
+        <BitmapImage x:Key="StarIconHard" UriSource="ms-appx:///Assets/Image/star-icon-hard.13c9ee51.png" />
         <local:ZZZRarityToIconConverter x:Key="ZZZRarityToIconConverter" />
     </Page.Resources>
 
@@ -103,12 +104,33 @@
                         <Grid.RowDefinitions>
                             <RowDefinition />
                             <RowDefinition />
+                            <RowDefinition />
                         </Grid.RowDefinitions>
                         <TextBlock Text="{x:Bind StartTime.ToString('yyyy-MM-dd', x:Null)}" />
+                        <!--  绝境模式  -->
                         <StackPanel Grid.Row="1"
                                     Orientation="Horizontal"
+                                    Spacing="4"
+                                    Visibility="{x:Bind HasHard, Converter={StaticResource BoolToVisibilityConverter}}">
+                            <TextBlock MinWidth="46"
+                                       VerticalAlignment="Center"
+                                       Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                       IsTextScaleFactorEnabled="False"
+                                       Text="{x:Bind HardTotalScore}" />
+                            <Image Width="20"
+                                   Height="20"
+                                   Source="{StaticResource StarIconHard}" />
+                            <TextBlock VerticalAlignment="Center"
+                                       Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                       IsTextScaleFactorEnabled="False">
+                                <Run Text="x" /><Run Text="{x:Bind HardTotalStar}" />
+                            </TextBlock>
+                        </StackPanel>
+                        <!--  试炼模式  -->
+                        <StackPanel Grid.Row="2"
+                                    Orientation="Horizontal"
                                     Spacing="4">
-                            <TextBlock MinWidth="44"
+                            <TextBlock MinWidth="46"
                                        VerticalAlignment="Center"
                                        Foreground="{ThemeResource TextFillColorSecondaryBrush}"
                                        IsTextScaleFactorEnabled="False"
@@ -118,8 +140,9 @@
                                    Source="{StaticResource StarIconLight}" />
                             <TextBlock VerticalAlignment="Center"
                                        Foreground="{ThemeResource TextFillColorSecondaryBrush}"
-                                       IsTextScaleFactorEnabled="False"
-                                       Text="{x:Bind TotalStar}" />
+                                       IsTextScaleFactorEnabled="False">
+                                <Run Text="x" /><Run Text="{x:Bind TotalStar}" />
+                            </TextBlock>
                         </StackPanel>
                     </Grid>
                 </DataTemplate>
@@ -140,6 +163,305 @@
                         <Run Text=" - " />
                         <Run Text="{x:Bind CurrentDeadlyAssault.EndTime.ToString('yyyy/MM/dd', x:Null)}" />
                     </TextBlock>
+                </Grid>
+
+                <!--  绝境模式  -->
+                <Grid MaxWidth="680"
+                      Padding="16,12,16,12"
+                      HorizontalAlignment="Center"
+                      Background="{ThemeResource CustomOverlayAcrylicBrush}"
+                      CornerRadius="8"
+                      RowSpacing="8"
+                      Shadow="{ThemeResource ThemeShadow}"
+                      Translation="0,0,16"
+                      Visibility="{x:Bind CurrentDeadlyAssault.HasHard, Converter={StaticResource BoolToVisibilityConverter}}">
+                    <Grid.RowDefinitions>
+                        <RowDefinition />
+                        <RowDefinition Height="Auto" />
+                    </Grid.RowDefinitions>
+
+                    <!--  通关评分  -->
+                    <Grid>
+                        <StackPanel Margin="4,4,0,0">
+                            <TextBlock FontWeight="Bold" Text="{x:Bind lang:Lang.DeadlyAssaultPage_AdversityMode}" />
+                            <StackPanel Orientation="Horizontal" Spacing="12">
+                                <TextBlock FontSize="28"
+                                           FontWeight="Bold"
+                                           Text="{x:Bind CurrentDeadlyAssault.HardTotalScore}" />
+                                <TextBlock Margin="0,0,0,6"
+                                           VerticalAlignment="Bottom"
+                                           Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                           Text="{x:Bind local:DeadlyAssaultPage.RankPercentText(CurrentDeadlyAssault.HardRankPercent)}" />
+                            </StackPanel>
+                        </StackPanel>
+
+                        <!--  Total Star  -->
+                        <StackPanel HorizontalAlignment="Right"
+                                    VerticalAlignment="Center"
+                                    Orientation="Horizontal"
+                                    Spacing="8">
+                            <Image Width="36"
+                                   Height="36"
+                                   VerticalAlignment="Center"
+                                   Source="{StaticResource StarIconHard}" />
+                            <TextBlock Margin="0,0,4,0"
+                                       VerticalAlignment="Center"
+                                       FontSize="18">
+                                <Run Text="x" /><Run Text="{x:Bind CurrentDeadlyAssault.HardTotalStar}" />
+                            </TextBlock>
+                        </StackPanel>
+                    </Grid>
+
+                    <!--  Boss Node  -->
+                    <ItemsControl Grid.Row="1"
+                                  ItemsSource="{x:Bind CurrentDeadlyAssault.HardNodes}">
+                        <ItemsControl.ItemsPanel>
+                            <ItemsPanelTemplate>
+                                <StackPanel Spacing="12" />
+                            </ItemsPanelTemplate>
+                        </ItemsControl.ItemsPanel>
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate x:DataType="fic:DeadlyAssaultNode">
+                                <Grid Padding="12,12,12,12"
+                                      Background="{ThemeResource CustomOverlayAcrylicBrush}"
+                                      ColumnSpacing="16"
+                                      CornerRadius="12"
+                                      RowSpacing="4"
+                                      Shadow="{ThemeResource ThemeShadow}"
+                                      Translation="0,0,16">
+                                    <Grid.RowDefinitions>
+                                        <RowDefinition Height="Auto" />
+                                        <RowDefinition Height="Auto" />
+                                        <RowDefinition Height="Auto" />
+                                        <RowDefinition />
+                                    </Grid.RowDefinitions>
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="Auto" />
+                                        <ColumnDefinition Width="Auto" />
+                                        <ColumnDefinition />
+                                    </Grid.ColumnDefinitions>
+                                    <!--  Boss Icon  -->
+                                    <Grid Grid.RowSpan="4"
+                                          Width="142"
+                                          Height="194"
+                                          VerticalAlignment="Top">
+                                        <sc:CachedImage Name="BossBg"
+                                                        HorizontalAlignment="Center"
+                                                        VerticalAlignment="Center"
+                                                        CornerRadius="16"
+                                                        Source="{x:Bind Boss[0].BgIcon}"
+                                                        Stretch="UniformToFill" />
+                                        <sc:CachedImage HorizontalAlignment="Center"
+                                                        VerticalAlignment="Center"
+                                                        CornerRadius="16"
+                                                        Source="{x:Bind Boss[0].Icon}"
+                                                        Stretch="Uniform" />
+                                        <sc:CachedImage Width="48"
+                                                        Height="48"
+                                                        Margin="0,0,4,4"
+                                                        HorizontalAlignment="Right"
+                                                        VerticalAlignment="Bottom"
+                                                        Source="{x:Bind Boss[0].RaceIcon}" />
+                                        <Border x:Name="InnerStrokeBorder"
+                                                BorderBrush="#70FFFFFF"
+                                                BorderThickness="2"
+                                                CornerRadius="16" />
+                                    </Grid>
+                                    <!--  Boss Name  -->
+                                    <TextBlock Grid.Column="1"
+                                               FontSize="16"
+                                               FontWeight="Bold"
+                                               Text="{x:Bind Boss[0].Name}" />
+                                    <!--  Score  -->
+                                    <StackPanel Grid.Row="1"
+                                                Grid.Column="1"
+                                                HorizontalAlignment="Left"
+                                                Orientation="Horizontal"
+                                                Spacing="2">
+                                        <TextBlock VerticalAlignment="Center"
+                                                   FontSize="24"
+                                                   FontWeight="Bold"
+                                                   Text="{x:Bind Score}" />
+                                        <ItemsControl Margin="4,3,0,0"
+                                                      VerticalAlignment="Center"
+                                                      ItemsSource="{x:Bind linq:Enumerable.Range(0, Star)}">
+                                            <ItemsControl.ItemsPanel>
+                                                <ItemsPanelTemplate>
+                                                    <StackPanel Orientation="Horizontal" />
+                                                </ItemsPanelTemplate>
+                                            </ItemsControl.ItemsPanel>
+                                            <ItemsControl.ItemTemplate>
+                                                <DataTemplate>
+                                                    <Image Width="24"
+                                                           Height="24"
+                                                           Source="{StaticResource StarIconHard}" />
+                                                </DataTemplate>
+                                            </ItemsControl.ItemTemplate>
+                                        </ItemsControl>
+                                    </StackPanel>
+                                    <!--  通关时刻  -->
+                                    <TextBlock Grid.Row="2"
+                                               Grid.Column="1"
+                                               FontSize="12">
+                                        <Run Foreground="{ThemeResource TextFillColorSecondaryBrush}" Text="{x:Bind lang:Lang.ClearedAt}" />
+                                        <Run Text="{x:Bind ChallengeTime.ToString('yyyy-MM-dd HH:mm:ss', x:Null)}" />
+                                    </TextBlock>
+                                    <!--  代理人  -->
+                                    <StackPanel Grid.Row="3"
+                                                Grid.Column="1"
+                                                Margin="0,4,0,0"
+                                                HorizontalAlignment="Left"
+                                                VerticalAlignment="Top"
+                                                Orientation="Horizontal"
+                                                Spacing="8">
+                                        <!--  角色  -->
+                                        <ItemsRepeater ItemsSource="{x:Bind Avatars}">
+                                            <ItemsRepeater.Layout>
+                                                <StackLayout Orientation="Horizontal" Spacing="8" />
+                                            </ItemsRepeater.Layout>
+                                            <ItemsRepeater.ItemTemplate>
+                                                <DataTemplate x:DataType="scgz:ZZZAvatar">
+                                                    <Grid Width="76" Height="94">
+                                                        <Border Width="76"
+                                                                Height="94"
+                                                                VerticalAlignment="Top"
+                                                                Background="#0A0A0A"
+                                                                CornerRadius="8" />
+                                                        <!--  背景  -->
+                                                        <sc:CachedImage Margin="2,2,2,2"
+                                                                        HorizontalAlignment="Center"
+                                                                        VerticalAlignment="Top"
+                                                                        CornerRadius="8,8,0,0"
+                                                                        Source="ms-appx:///Assets/Image/ZZZ_AvatarCard_Background.png" />
+                                                        <!--  图片  -->
+                                                        <sc:CachedImage Width="72"
+                                                                        Height="72"
+                                                                        Margin="2,2,2,2"
+                                                                        VerticalAlignment="Top"
+                                                                        CornerRadius="8,8,0,0"
+                                                                        Source="{x:Bind RoleSquareUrl}"
+                                                                        Stretch="UniformToFill" />
+                                                        <!--  等级  -->
+                                                        <TextBlock Margin="0,0,0,2"
+                                                                   HorizontalAlignment="Center"
+                                                                   VerticalAlignment="Bottom"
+                                                                   FontSize="12"
+                                                                   Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                                                   IsTextScaleFactorEnabled="False">
+                                                            <Run Text="Lv." /><Run Text="{x:Bind Level}" />
+                                                        </TextBlock>
+                                                        <!--  稀有度  -->
+                                                        <Border Width="22"
+                                                                Height="22"
+                                                                HorizontalAlignment="Left"
+                                                                VerticalAlignment="Top"
+                                                                Background="Black"
+                                                                CornerRadius="8,0,4,0">
+                                                            <Image Width="16"
+                                                                   Height="16"
+                                                                   HorizontalAlignment="Center"
+                                                                   VerticalAlignment="Center"
+                                                                   Source="{x:Bind Rarity, Converter={StaticResource ZZZRarityToIconConverter}}" />
+                                                        </Border>
+                                                        <!--  影画  -->
+                                                        <Border HorizontalAlignment="Right"
+                                                                VerticalAlignment="Top"
+                                                                Background="#A0000000"
+                                                                CornerRadius="0,8,0,4"
+                                                                Visibility="{x:Bind sfgr:AvatarRankHelper.RankToVisibility(Rank)}">
+                                                            <TextBlock Margin="4,2,4,2"
+                                                                       FontSize="14"
+                                                                       Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                                                       IsTextScaleFactorEnabled="False"
+                                                                       Text="{x:Bind Rank}" />
+                                                        </Border>
+                                                    </Grid>
+                                                </DataTemplate>
+                                            </ItemsRepeater.ItemTemplate>
+                                        </ItemsRepeater>
+                                        <!--  邦布  -->
+                                        <Grid Width="58"
+                                              Height="78"
+                                              Margin="0,15,0,0"
+                                              Background="#0A0A0A"
+                                              CornerRadius="8">
+                                            <!--  背景  -->
+                                            <sc:CachedImage Width="54"
+                                                            Height="56"
+                                                            Margin="2,2,2,2"
+                                                            HorizontalAlignment="Center"
+                                                            VerticalAlignment="Top"
+                                                            CornerRadius="8,8,0,0"
+                                                            Source="ms-appx:///Assets/Image/ZZZ_AvatarCard_Background.png"
+                                                            Stretch="UniformToFill" />
+                                            <!--  邦布图  -->
+                                            <Border Width="54"
+                                                    Height="56"
+                                                    Margin="2,2,2,2"
+                                                    VerticalAlignment="Top"
+                                                    cw:UIElementExtensions.ClipToBounds="True"
+                                                    CornerRadius="8,8,0,0">
+                                                <sc:CachedImage Height="84"
+                                                                Margin="-8,-8,0,0"
+                                                                HorizontalAlignment="Left"
+                                                                VerticalAlignment="Top"
+                                                                CornerRadius="8,8,0,0"
+                                                                Source="{x:Bind Buddy.RectangleUrl}"
+                                                                Stretch="UniformToFill" />
+                                            </Border>
+                                            <!--  等级  -->
+                                            <TextBlock Margin="0,0,0,2"
+                                                       HorizontalAlignment="Center"
+                                                       VerticalAlignment="Bottom"
+                                                       FontSize="12"
+                                                       Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                                       IsTextScaleFactorEnabled="False">
+                                                <Run Text="Lv." /><Run Text="{x:Bind Buddy.Level}" />
+                                            </TextBlock>
+                                            <!--  稀有度  -->
+                                            <Border Width="20"
+                                                    Height="20"
+                                                    HorizontalAlignment="Left"
+                                                    VerticalAlignment="Top"
+                                                    Background="Black"
+                                                    CornerRadius="8,0,4,0">
+                                                <Image Width="16"
+                                                       Height="16"
+                                                       HorizontalAlignment="Center"
+                                                       VerticalAlignment="Center"
+                                                       Source="{x:Bind Buddy.Rarity, Converter={StaticResource ZZZRarityToIconConverter}}" />
+                                            </Border>
+                                        </Grid>
+                                    </StackPanel>
+                                    <!--  Buff  -->
+                                    <Grid Grid.RowSpan="4"
+                                          Grid.Column="2"
+                                          VerticalAlignment="Top">
+                                        <Grid.RowDefinitions>
+                                            <RowDefinition />
+                                            <RowDefinition Height="Auto" />
+                                        </Grid.RowDefinitions>
+                                        <StackPanel Orientation="Horizontal">
+                                            <sc:CachedImage Width="32"
+                                                            Height="32"
+                                                            Source="{x:Bind Buff[0].Icon}" />
+                                            <TextBlock Margin="8,0,0,2"
+                                                       HorizontalAlignment="Center"
+                                                       VerticalAlignment="Center"
+                                                       FontSize="16"
+                                                       Text="{x:Bind Buff[0].Name}" />
+                                        </StackPanel>
+                                        <sc:ColorfulTextBlock Grid.Row="1"
+                                                              Margin="0,8,0,0"
+                                                              FontSize="12"
+                                                              Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                                              Text="{x:Bind Buff[0].Desc}"
+                                                              TextWrapping="Wrap" />
+                                    </Grid>
+                                </Grid>
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
                 </Grid>
 
                 <!--  试炼模式  -->
@@ -184,14 +506,16 @@
                                    Source="{StaticResource StarIconLight}" />
                             <TextBlock Margin="0,0,4,0"
                                        VerticalAlignment="Center"
-                                       FontSize="16"
-                                       Text="{x:Bind CurrentDeadlyAssault.TotalStar}" />
+                                       FontSize="18">
+                                <Run Text="x" /><Run Text="{x:Bind CurrentDeadlyAssault.TotalStar}" />
+                            </TextBlock>
                         </StackPanel>
                     </Grid>
 
 
                     <!--  Boss Node  -->
-                    <ItemsControl Grid.Row="1" ItemsSource="{x:Bind CurrentDeadlyAssault.AllNodes}">
+                    <ItemsControl Grid.Row="1"
+                                  ItemsSource="{x:Bind CurrentDeadlyAssault.AllNodes}">
                         <ItemsControl.ItemsPanel>
                             <ItemsPanelTemplate>
                                 <StackPanel Spacing="12" />

--- a/src/Starward/Features/GameRecord/ZZZ/DeadlyAssaultPage.xaml
+++ b/src/Starward/Features/GameRecord/ZZZ/DeadlyAssaultPage.xaml
@@ -188,10 +188,19 @@
                                 <TextBlock FontSize="28"
                                            FontWeight="Bold"
                                            Text="{x:Bind CurrentDeadlyAssault.HardTotalScore}" />
-                                <TextBlock Margin="0,0,0,6"
-                                           VerticalAlignment="Bottom"
-                                           Foreground="{ThemeResource TextFillColorSecondaryBrush}"
-                                           Text="{x:Bind local:DeadlyAssaultPage.RankPercentText(CurrentDeadlyAssault.HardRankPercent)}" />
+                                <Grid Margin="0,0,0,6"
+                                      VerticalAlignment="Bottom">
+                                    <Image Height="20"
+                                           Stretch="Uniform"
+                                           Source="{x:Bind local:DeadlyAssaultPage.RankBackground(CurrentDeadlyAssault.HardRankPercent)}" />
+                                    <TextBlock Margin="8,0,0,1"
+                                               HorizontalAlignment="Left"
+                                               VerticalAlignment="Center"
+                                               FontSize="14"
+                                               Foreground="Black"
+                                               FontWeight="Bold"
+                                               Text="{x:Bind local:DeadlyAssaultPage.RankPercentText(CurrentDeadlyAssault.HardRankPercent)}" />
+                                </Grid>
                             </StackPanel>
                         </StackPanel>
 
@@ -206,7 +215,8 @@
                                    Source="{StaticResource StarIconHard}" />
                             <TextBlock Margin="0,0,4,0"
                                        VerticalAlignment="Center"
-                                       FontSize="18">
+                                       FontSize="20"
+                                       FontWeight="Bold">
                                 <Run Text="x" /><Run Text="{x:Bind CurrentDeadlyAssault.HardTotalStar}" />
                             </TextBlock>
                         </StackPanel>
@@ -488,10 +498,19 @@
                                 <TextBlock FontSize="28"
                                            FontWeight="Bold"
                                            Text="{x:Bind CurrentDeadlyAssault.TotalScore}" />
-                                <TextBlock Margin="0,0,0,6"
-                                           VerticalAlignment="Bottom"
-                                           Foreground="{ThemeResource TextFillColorSecondaryBrush}"
-                                           Text="{x:Bind local:DeadlyAssaultPage.RankPercentText(CurrentDeadlyAssault.RankPercent)}" />
+                                <Grid Margin="0,0,0,6"
+                                      VerticalAlignment="Bottom">
+                                    <Image Height="20"
+                                           Stretch="Uniform"
+                                           Source="{x:Bind local:DeadlyAssaultPage.RankBackground(CurrentDeadlyAssault.RankPercent)}" />
+                                    <TextBlock Margin="8,0,0,1"
+                                               HorizontalAlignment="Left"
+                                               VerticalAlignment="Center"
+                                               FontSize="14"
+                                               Foreground="Black"
+                                               FontWeight="Bold"
+                                               Text="{x:Bind local:DeadlyAssaultPage.RankPercentText(CurrentDeadlyAssault.RankPercent)}" />
+                                </Grid>
                             </StackPanel>
                         </StackPanel>
 
@@ -506,7 +525,8 @@
                                    Source="{StaticResource StarIconLight}" />
                             <TextBlock Margin="0,0,4,0"
                                        VerticalAlignment="Center"
-                                       FontSize="18">
+                                       FontSize="20"
+                                       FontWeight="Bold">
                                 <Run Text="x" /><Run Text="{x:Bind CurrentDeadlyAssault.TotalStar}" />
                             </TextBlock>
                         </StackPanel>

--- a/src/Starward/Features/GameRecord/ZZZ/DeadlyAssaultPage.xaml
+++ b/src/Starward/Features/GameRecord/ZZZ/DeadlyAssaultPage.xaml
@@ -142,306 +142,304 @@
                     </TextBlock>
                 </Grid>
 
-                <!--  统计  -->
-                <Grid Padding="8"
+                <!--  试炼模式  -->
+                <Grid MaxWidth="680"
+                      Padding="16,12,16,12"
+                      HorizontalAlignment="Center"
                       Background="{ThemeResource CustomOverlayAcrylicBrush}"
                       CornerRadius="8"
+                      RowSpacing="8"
                       Shadow="{ThemeResource ThemeShadow}"
                       Translation="0,0,16">
-                    <Grid.ColumnDefinitions>
-                        <ColumnDefinition />
-                        <ColumnDefinition />
-                        <ColumnDefinition />
-                    </Grid.ColumnDefinitions>
-                    <!--  总分  -->
-                    <TextBlock Name="TextBlock_Battles"
-                               Grid.Column="2"
-                               HorizontalAlignment="Center"
-                               VerticalAlignment="Center">
-                        <Run Foreground="{ThemeResource TextFillColorSecondaryBrush}" Text="{x:Bind lang:Lang.DeadlyAssaultPage_TotalScore}" />
-                        <Run Text="" />
-                        <Run Text="{x:Bind CurrentDeadlyAssault.TotalScore}" />
-                    </TextBlock>
-
-                    <!--  全服排名  -->
-                    <TextBlock Name="TextBlock_Deepest"
-                               Grid.Column="1"
-                               HorizontalAlignment="Center"
-                               VerticalAlignment="Center"
-                               TextTrimming="CharacterEllipsis">
-                        <Run Foreground="{ThemeResource TextFillColorSecondaryBrush}" Text="{x:Bind lang:Lang.DeadlyAssaultPage_GlobalTopPercent}" />
-                        <Run Text="" />
-                        <Run Text="{x:Bind local:DeadlyAssaultPage.RankPercentText(CurrentDeadlyAssault.RankPercent)}" />
-                    </TextBlock>
-
-                    <!--  Total Star  -->
-                    <StackPanel Grid.RowSpan="2"
-                                HorizontalAlignment="Center"
-                                Orientation="Horizontal"
-                                Spacing="8">
-                        <Image Width="24"
-                               Height="24"
-                               VerticalAlignment="Center"
-                               Source="{StaticResource StarIconLight}" />
-                        <TextBlock VerticalAlignment="Center"
-                                   FontSize="16"
-                                   Text="{x:Bind CurrentDeadlyAssault.TotalStar}" />
-                    </StackPanel>
-                </Grid>
+                    <Grid.RowDefinitions>
+                        <RowDefinition />
+                        <RowDefinition Height="Auto" />
+                    </Grid.RowDefinitions>
 
 
-                <!--  Boss 节点  -->
-                <ItemsControl Margin="0,8,0,0" ItemsSource="{x:Bind CurrentDeadlyAssault.AllNodes}">
-                    <ItemsControl.ItemsPanel>
-                        <ItemsPanelTemplate>
-                            <StackPanel Spacing="16" />
-                        </ItemsPanelTemplate>
-                    </ItemsControl.ItemsPanel>
-                    <ItemsControl.ItemTemplate>
-                        <DataTemplate x:DataType="fic:DeadlyAssaultNode">
-                            <Grid Padding="8,12,8,12"
-                                  Background="{ThemeResource CustomOverlayAcrylicBrush}"
-                                  ColumnSpacing="16"
-                                  CornerRadius="12"
-                                  RowSpacing="4"
-                                  Shadow="{ThemeResource ThemeShadow}"
-                                  Translation="0,0,16">
-                                <Grid.RowDefinitions>
-                                    <RowDefinition Height="Auto" />
-                                    <RowDefinition Height="Auto" />
-                                    <RowDefinition Height="Auto" />
-                                    <RowDefinition />
-                                </Grid.RowDefinitions>
-                                <Grid.ColumnDefinitions>
-                                    <ColumnDefinition Width="Auto" />
-                                    <ColumnDefinition Width="Auto" />
-                                    <ColumnDefinition />
-                                </Grid.ColumnDefinitions>
-                                <!--  Boss Icon  -->
-                                <Grid Grid.RowSpan="4"
-                                      Width="142"
-                                      Height="194"
-                                      VerticalAlignment="Top">
-                                    <sc:CachedImage Name="BossBg"
-                                                    HorizontalAlignment="Center"
-                                                    VerticalAlignment="Center"
-                                                    CornerRadius="16"
-                                                    Source="{x:Bind Boss[0].BgIcon}"
-                                                    Stretch="UniformToFill" />
-                                    <sc:CachedImage HorizontalAlignment="Center"
-                                                    VerticalAlignment="Center"
-                                                    CornerRadius="16"
-                                                    Source="{x:Bind Boss[0].Icon}"
-                                                    Stretch="Uniform" />
-                                    <sc:CachedImage Width="48"
-                                                    Height="48"
-                                                    Margin="0,0,4,4"
-                                                    HorizontalAlignment="Right"
-                                                    VerticalAlignment="Bottom"
-                                                    Source="{x:Bind Boss[0].RaceIcon}" />
-                                    <Border x:Name="InnerStrokeBorder"
-                                            BorderBrush="#70FFFFFF"
-                                            BorderThickness="2"
-                                            CornerRadius="16" />
-                                </Grid>
-                                <!--  Boss Name  -->
-                                <TextBlock Grid.Column="1"
-                                           FontSize="16"
+                    <!--  通关评分  -->
+                    <Grid>
+                        <!--  TotalScore  -->
+                        <StackPanel Margin="4,4,0,0">
+                            <TextBlock FontWeight="Bold" Text="{x:Bind lang:Lang.DeadlyAssaultPage_TrialMode}" />
+                            <StackPanel Orientation="Horizontal" Spacing="12">
+                                <TextBlock FontSize="28"
                                            FontWeight="Bold"
+                                           Text="{x:Bind CurrentDeadlyAssault.TotalScore}" />
+                                <TextBlock Margin="0,0,0,6"
+                                           VerticalAlignment="Bottom"
                                            Foreground="{ThemeResource TextFillColorSecondaryBrush}"
-                                           Text="{x:Bind Boss[0].Name}" />
-                                <!--  Score  -->
-                                <StackPanel Grid.Row="1"
-                                            Grid.Column="1"
-                                            HorizontalAlignment="Left"
-                                            Orientation="Horizontal"
-                                            Spacing="2">
-                                    <TextBlock VerticalAlignment="Center"
-                                               FontSize="24"
-                                               FontWeight="Bold"
-                                               Foreground="{ThemeResource TextFillColorSecondaryBrush}"
-                                               Text="{x:Bind Score}" />
-                                    <ItemsControl Margin="4,3,0,0"
-                                                  VerticalAlignment="Center"
-                                                  ItemsSource="{x:Bind linq:Enumerable.Range(0, Star)}">
-                                        <ItemsControl.ItemsPanel>
-                                            <ItemsPanelTemplate>
-                                                <StackPanel Orientation="Horizontal" />
-                                            </ItemsPanelTemplate>
-                                        </ItemsControl.ItemsPanel>
-                                        <ItemsControl.ItemTemplate>
-                                            <DataTemplate>
-                                                <Image Width="24"
-                                                       Height="24"
-                                                       Source="{StaticResource StarIconLight}" />
-                                            </DataTemplate>
-                                        </ItemsControl.ItemTemplate>
-                                    </ItemsControl>
-                                </StackPanel>
-                                <!--  通关时刻  -->
-                                <TextBlock Grid.Row="2"
-                                           Grid.Column="1"
-                                           FontSize="12">
-                                    <Run Foreground="{ThemeResource TextFillColorSecondaryBrush}" Text="{x:Bind lang:Lang.ClearedAt}" />
-                                    <Run Text="{x:Bind ChallengeTime.ToString('yyyy-MM-dd HH:mm:ss', x:Null)}" />
-                                </TextBlock>
-                                <!--  代理人  -->
-                                <StackPanel Grid.Row="3"
-                                            Grid.Column="1"
-                                            Margin="0,4,0,0"
-                                            HorizontalAlignment="Left"
-                                            VerticalAlignment="Top"
-                                            Orientation="Horizontal"
-                                            Spacing="8">
-                                    <!--  角色  -->
-                                    <ItemsRepeater ItemsSource="{x:Bind Avatars}">
-                                        <ItemsRepeater.Layout>
-                                            <StackLayout Orientation="Horizontal" Spacing="8" />
-                                        </ItemsRepeater.Layout>
-                                        <ItemsRepeater.ItemTemplate>
-                                            <DataTemplate x:DataType="scgz:ZZZAvatar">
-                                                <Grid Width="76" Height="94">
-                                                    <Border Width="76"
-                                                            Height="94"
-                                                            VerticalAlignment="Top"
-                                                            Background="#0A0A0A"
-                                                            CornerRadius="8" />
-                                                    <!--  背景  -->
-                                                    <sc:CachedImage Margin="2,2,2,2"
-                                                                    HorizontalAlignment="Center"
-                                                                    VerticalAlignment="Top"
-                                                                    CornerRadius="8,8,0,0"
-                                                                    Source="ms-appx:///Assets/Image/ZZZ_AvatarCard_Background.png" />
-                                                    <!--  图片  -->
-                                                    <sc:CachedImage Width="72"
-                                                                    Height="72"
-                                                                    Margin="2,2,2,2"
-                                                                    VerticalAlignment="Top"
-                                                                    CornerRadius="8,8,0,0"
-                                                                    Source="{x:Bind RoleSquareUrl}"
-                                                                    Stretch="UniformToFill" />
-                                                    <!--  等级  -->
-                                                    <TextBlock Margin="0,0,0,2"
-                                                               HorizontalAlignment="Center"
-                                                               VerticalAlignment="Bottom"
-                                                               FontSize="12"
-                                                               Foreground="{ThemeResource TextFillColorSecondaryBrush}"
-                                                               IsTextScaleFactorEnabled="False">
-                                                        <Run Text="Lv." /><Run Text="{x:Bind Level}" />
-                                                    </TextBlock>
-                                                    <!--  稀有度  -->
-                                                    <Border Width="22"
-                                                            Height="22"
-                                                            HorizontalAlignment="Left"
-                                                            VerticalAlignment="Top"
-                                                            Background="Black"
-                                                            CornerRadius="8,0,4,0">
-                                                        <Image Width="16"
-                                                               Height="16"
-                                                               HorizontalAlignment="Center"
-                                                               VerticalAlignment="Center"
-                                                               Source="{x:Bind Rarity, Converter={StaticResource ZZZRarityToIconConverter}}" />
-                                                    </Border>
-                                                    <!--  影画  -->
-                                                    <Border HorizontalAlignment="Right"
-                                                            VerticalAlignment="Top"
-                                                            Background="#A0000000"
-                                                            CornerRadius="0,8,0,4"
-                                                            Visibility="{x:Bind sfgr:AvatarRankHelper.RankToVisibility(Rank)}">
-                                                        <TextBlock Margin="4,2,4,2"
-                                                                   FontSize="14"
-                                                                   Foreground="{ThemeResource TextFillColorSecondaryBrush}"
-                                                                   IsTextScaleFactorEnabled="False"
-                                                                   Text="{x:Bind Rank}" />
-                                                    </Border>
-                                                </Grid>
-                                            </DataTemplate>
-                                        </ItemsRepeater.ItemTemplate>
-                                    </ItemsRepeater>
-                                    <!--  邦布  -->
-                                    <Grid Width="58"
-                                          Height="78"
-                                          Margin="0,15,0,0"
-                                          Background="#0A0A0A"
-                                          CornerRadius="8">
-                                        <!--  背景  -->
-                                        <sc:CachedImage Width="54"
-                                                        Height="56"
-                                                        Margin="2,2,2,2"
+                                           Text="{x:Bind local:DeadlyAssaultPage.RankPercentText(CurrentDeadlyAssault.RankPercent)}" />
+                            </StackPanel>
+                        </StackPanel>
+
+                        <!--  Total Star  -->
+                        <StackPanel HorizontalAlignment="Right"
+                                    VerticalAlignment="Center"
+                                    Orientation="Horizontal"
+                                    Spacing="8">
+                            <Image Width="36"
+                                   Height="36"
+                                   VerticalAlignment="Center"
+                                   Source="{StaticResource StarIconLight}" />
+                            <TextBlock Margin="0,0,4,0"
+                                       VerticalAlignment="Center"
+                                       FontSize="16"
+                                       Text="{x:Bind CurrentDeadlyAssault.TotalStar}" />
+                        </StackPanel>
+                    </Grid>
+
+
+                    <!--  Boss Node  -->
+                    <ItemsControl Grid.Row="1" ItemsSource="{x:Bind CurrentDeadlyAssault.AllNodes}">
+                        <ItemsControl.ItemsPanel>
+                            <ItemsPanelTemplate>
+                                <StackPanel Spacing="12" />
+                            </ItemsPanelTemplate>
+                        </ItemsControl.ItemsPanel>
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate x:DataType="fic:DeadlyAssaultNode">
+                                <Grid Padding="12,12,12,12"
+                                      Background="{ThemeResource CustomOverlayAcrylicBrush}"
+                                      ColumnSpacing="16"
+                                      CornerRadius="12"
+                                      RowSpacing="4"
+                                      Shadow="{ThemeResource ThemeShadow}"
+                                      Translation="0,0,16">
+                                    <Grid.RowDefinitions>
+                                        <RowDefinition Height="Auto" />
+                                        <RowDefinition Height="Auto" />
+                                        <RowDefinition Height="Auto" />
+                                        <RowDefinition />
+                                    </Grid.RowDefinitions>
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="Auto" />
+                                        <ColumnDefinition Width="Auto" />
+                                        <ColumnDefinition />
+                                    </Grid.ColumnDefinitions>
+                                    <!--  Boss Icon  -->
+                                    <Grid Grid.RowSpan="4"
+                                          Width="142"
+                                          Height="194"
+                                          VerticalAlignment="Top">
+                                        <sc:CachedImage Name="BossBg"
                                                         HorizontalAlignment="Center"
-                                                        VerticalAlignment="Top"
-                                                        CornerRadius="8,8,0,0"
-                                                        Source="ms-appx:///Assets/Image/ZZZ_AvatarCard_Background.png"
+                                                        VerticalAlignment="Center"
+                                                        CornerRadius="16"
+                                                        Source="{x:Bind Boss[0].BgIcon}"
                                                         Stretch="UniformToFill" />
-                                        <!--  邦布图  -->
-                                        <Border Width="54"
-                                                Height="56"
-                                                Margin="2,2,2,2"
-                                                VerticalAlignment="Top"
-                                                cw:UIElementExtensions.ClipToBounds="True"
-                                                CornerRadius="8,8,0,0">
-                                            <sc:CachedImage Height="84"
-                                                            Margin="-8,-8,0,0"
-                                                            HorizontalAlignment="Left"
-                                                            VerticalAlignment="Top"
-                                                            CornerRadius="8,8,0,0"
-                                                            Source="{x:Bind Buddy.RectangleUrl}"
-                                                            Stretch="UniformToFill" />
-                                        </Border>
-                                        <!--  等级  -->
-                                        <TextBlock Margin="0,0,0,2"
-                                                   HorizontalAlignment="Center"
-                                                   VerticalAlignment="Bottom"
-                                                   FontSize="12"
-                                                   Foreground="{ThemeResource TextFillColorSecondaryBrush}"
-                                                   IsTextScaleFactorEnabled="False">
-                                            <Run Text="Lv." /><Run Text="{x:Bind Buddy.Level}" />
-                                        </TextBlock>
-                                        <!--  稀有度  -->
-                                        <Border Width="20"
-                                                Height="20"
+                                        <sc:CachedImage HorizontalAlignment="Center"
+                                                        VerticalAlignment="Center"
+                                                        CornerRadius="16"
+                                                        Source="{x:Bind Boss[0].Icon}"
+                                                        Stretch="Uniform" />
+                                        <sc:CachedImage Width="48"
+                                                        Height="48"
+                                                        Margin="0,0,4,4"
+                                                        HorizontalAlignment="Right"
+                                                        VerticalAlignment="Bottom"
+                                                        Source="{x:Bind Boss[0].RaceIcon}" />
+                                        <Border x:Name="InnerStrokeBorder"
+                                                BorderBrush="#70FFFFFF"
+                                                BorderThickness="2"
+                                                CornerRadius="16" />
+                                    </Grid>
+                                    <!--  Boss Name  -->
+                                    <TextBlock Grid.Column="1"
+                                               FontSize="16"
+                                               FontWeight="Bold"
+                                               Text="{x:Bind Boss[0].Name}" />
+                                    <!--  Score  -->
+                                    <StackPanel Grid.Row="1"
+                                                Grid.Column="1"
+                                                HorizontalAlignment="Left"
+                                                Orientation="Horizontal"
+                                                Spacing="2">
+                                        <TextBlock VerticalAlignment="Center"
+                                                   FontSize="24"
+                                                   FontWeight="Bold"
+                                                   Text="{x:Bind Score}" />
+                                        <ItemsControl Margin="4,3,0,0"
+                                                      VerticalAlignment="Center"
+                                                      ItemsSource="{x:Bind linq:Enumerable.Range(0, Star)}">
+                                            <ItemsControl.ItemsPanel>
+                                                <ItemsPanelTemplate>
+                                                    <StackPanel Orientation="Horizontal" />
+                                                </ItemsPanelTemplate>
+                                            </ItemsControl.ItemsPanel>
+                                            <ItemsControl.ItemTemplate>
+                                                <DataTemplate>
+                                                    <Image Width="24"
+                                                           Height="24"
+                                                           Source="{StaticResource StarIconLight}" />
+                                                </DataTemplate>
+                                            </ItemsControl.ItemTemplate>
+                                        </ItemsControl>
+                                    </StackPanel>
+                                    <!--  通关时刻  -->
+                                    <TextBlock Grid.Row="2"
+                                               Grid.Column="1"
+                                               FontSize="12">
+                                        <Run Foreground="{ThemeResource TextFillColorSecondaryBrush}" Text="{x:Bind lang:Lang.ClearedAt}" />
+                                        <Run Text="{x:Bind ChallengeTime.ToString('yyyy-MM-dd HH:mm:ss', x:Null)}" />
+                                    </TextBlock>
+                                    <!--  代理人  -->
+                                    <StackPanel Grid.Row="3"
+                                                Grid.Column="1"
+                                                Margin="0,4,0,0"
                                                 HorizontalAlignment="Left"
                                                 VerticalAlignment="Top"
-                                                Background="Black"
-                                                CornerRadius="8,0,4,0">
-                                            <Image Width="16"
-                                                   Height="16"
-                                                   HorizontalAlignment="Center"
-                                                   VerticalAlignment="Center"
-                                                   Source="{x:Bind Buddy.Rarity, Converter={StaticResource ZZZRarityToIconConverter}}" />
-                                        </Border>
-                                    </Grid>
-                                </StackPanel>
-                                <!--  Buff  -->
-                                <Grid Grid.RowSpan="4"
-                                      Grid.Column="2"
-                                      VerticalAlignment="Top">
-                                    <Grid.RowDefinitions>
-                                        <RowDefinition />
-                                        <RowDefinition Height="Auto" />
-                                    </Grid.RowDefinitions>
-                                    <StackPanel Orientation="Horizontal">
-                                        <sc:CachedImage Width="32"
-                                                        Height="32"
-                                                        Source="{x:Bind Buff[0].Icon}" />
-                                        <TextBlock Margin="8,0,0,2"
-                                                   HorizontalAlignment="Center"
-                                                   VerticalAlignment="Center"
-                                                   FontSize="16"
-                                                   Text="{x:Bind Buff[0].Name}" />
+                                                Orientation="Horizontal"
+                                                Spacing="8">
+                                        <!--  角色  -->
+                                        <ItemsRepeater ItemsSource="{x:Bind Avatars}">
+                                            <ItemsRepeater.Layout>
+                                                <StackLayout Orientation="Horizontal" Spacing="8" />
+                                            </ItemsRepeater.Layout>
+                                            <ItemsRepeater.ItemTemplate>
+                                                <DataTemplate x:DataType="scgz:ZZZAvatar">
+                                                    <Grid Width="76" Height="94">
+                                                        <Border Width="76"
+                                                                Height="94"
+                                                                VerticalAlignment="Top"
+                                                                Background="#0A0A0A"
+                                                                CornerRadius="8" />
+                                                        <!--  背景  -->
+                                                        <sc:CachedImage Margin="2,2,2,2"
+                                                                        HorizontalAlignment="Center"
+                                                                        VerticalAlignment="Top"
+                                                                        CornerRadius="8,8,0,0"
+                                                                        Source="ms-appx:///Assets/Image/ZZZ_AvatarCard_Background.png" />
+                                                        <!--  图片  -->
+                                                        <sc:CachedImage Width="72"
+                                                                        Height="72"
+                                                                        Margin="2,2,2,2"
+                                                                        VerticalAlignment="Top"
+                                                                        CornerRadius="8,8,0,0"
+                                                                        Source="{x:Bind RoleSquareUrl}"
+                                                                        Stretch="UniformToFill" />
+                                                        <!--  等级  -->
+                                                        <TextBlock Margin="0,0,0,2"
+                                                                   HorizontalAlignment="Center"
+                                                                   VerticalAlignment="Bottom"
+                                                                   FontSize="12"
+                                                                   Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                                                   IsTextScaleFactorEnabled="False">
+                                                            <Run Text="Lv." /><Run Text="{x:Bind Level}" />
+                                                        </TextBlock>
+                                                        <!--  稀有度  -->
+                                                        <Border Width="22"
+                                                                Height="22"
+                                                                HorizontalAlignment="Left"
+                                                                VerticalAlignment="Top"
+                                                                Background="Black"
+                                                                CornerRadius="8,0,4,0">
+                                                            <Image Width="16"
+                                                                   Height="16"
+                                                                   HorizontalAlignment="Center"
+                                                                   VerticalAlignment="Center"
+                                                                   Source="{x:Bind Rarity, Converter={StaticResource ZZZRarityToIconConverter}}" />
+                                                        </Border>
+                                                        <!--  影画  -->
+                                                        <Border HorizontalAlignment="Right"
+                                                                VerticalAlignment="Top"
+                                                                Background="#A0000000"
+                                                                CornerRadius="0,8,0,4"
+                                                                Visibility="{x:Bind sfgr:AvatarRankHelper.RankToVisibility(Rank)}">
+                                                            <TextBlock Margin="4,2,4,2"
+                                                                       FontSize="14"
+                                                                       Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                                                       IsTextScaleFactorEnabled="False"
+                                                                       Text="{x:Bind Rank}" />
+                                                        </Border>
+                                                    </Grid>
+                                                </DataTemplate>
+                                            </ItemsRepeater.ItemTemplate>
+                                        </ItemsRepeater>
+                                        <!--  邦布  -->
+                                        <Grid Width="58"
+                                              Height="78"
+                                              Margin="0,15,0,0"
+                                              Background="#0A0A0A"
+                                              CornerRadius="8">
+                                            <!--  背景  -->
+                                            <sc:CachedImage Width="54"
+                                                            Height="56"
+                                                            Margin="2,2,2,2"
+                                                            HorizontalAlignment="Center"
+                                                            VerticalAlignment="Top"
+                                                            CornerRadius="8,8,0,0"
+                                                            Source="ms-appx:///Assets/Image/ZZZ_AvatarCard_Background.png"
+                                                            Stretch="UniformToFill" />
+                                            <!--  邦布图  -->
+                                            <Border Width="54"
+                                                    Height="56"
+                                                    Margin="2,2,2,2"
+                                                    VerticalAlignment="Top"
+                                                    cw:UIElementExtensions.ClipToBounds="True"
+                                                    CornerRadius="8,8,0,0">
+                                                <sc:CachedImage Height="84"
+                                                                Margin="-8,-8,0,0"
+                                                                HorizontalAlignment="Left"
+                                                                VerticalAlignment="Top"
+                                                                CornerRadius="8,8,0,0"
+                                                                Source="{x:Bind Buddy.RectangleUrl}"
+                                                                Stretch="UniformToFill" />
+                                            </Border>
+                                            <!--  等级  -->
+                                            <TextBlock Margin="0,0,0,2"
+                                                       HorizontalAlignment="Center"
+                                                       VerticalAlignment="Bottom"
+                                                       FontSize="12"
+                                                       Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                                       IsTextScaleFactorEnabled="False">
+                                                <Run Text="Lv." /><Run Text="{x:Bind Buddy.Level}" />
+                                            </TextBlock>
+                                            <!--  稀有度  -->
+                                            <Border Width="20"
+                                                    Height="20"
+                                                    HorizontalAlignment="Left"
+                                                    VerticalAlignment="Top"
+                                                    Background="Black"
+                                                    CornerRadius="8,0,4,0">
+                                                <Image Width="16"
+                                                       Height="16"
+                                                       HorizontalAlignment="Center"
+                                                       VerticalAlignment="Center"
+                                                       Source="{x:Bind Buddy.Rarity, Converter={StaticResource ZZZRarityToIconConverter}}" />
+                                            </Border>
+                                        </Grid>
                                     </StackPanel>
-                                    <sc:ColorfulTextBlock Grid.Row="1"
-                                                          Margin="0,8,0,0"
-                                                          FontSize="12"
-                                                          Foreground="{ThemeResource TextFillColorSecondaryBrush}"
-                                                          Text="{x:Bind Buff[0].Desc}"
-                                                          TextWrapping="Wrap" />
+                                    <!--  Buff  -->
+                                    <Grid Grid.RowSpan="4"
+                                          Grid.Column="2"
+                                          VerticalAlignment="Top">
+                                        <Grid.RowDefinitions>
+                                            <RowDefinition />
+                                            <RowDefinition Height="Auto" />
+                                        </Grid.RowDefinitions>
+                                        <StackPanel Orientation="Horizontal">
+                                            <sc:CachedImage Width="32"
+                                                            Height="32"
+                                                            Source="{x:Bind Buff[0].Icon}" />
+                                            <TextBlock Margin="8,0,0,2"
+                                                       HorizontalAlignment="Center"
+                                                       VerticalAlignment="Center"
+                                                       FontSize="16"
+                                                       Text="{x:Bind Buff[0].Name}" />
+                                        </StackPanel>
+                                        <sc:ColorfulTextBlock Grid.Row="1"
+                                                              Margin="0,8,0,0"
+                                                              FontSize="12"
+                                                              Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                                              Text="{x:Bind Buff[0].Desc}"
+                                                              TextWrapping="Wrap" />
+                                    </Grid>
                                 </Grid>
-                            </Grid>
-                        </DataTemplate>
-                    </ItemsControl.ItemTemplate>
-                </ItemsControl>
-
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
+                </Grid>
 
             </StackPanel>
         </ScrollViewer>

--- a/src/Starward/Features/GameRecord/ZZZ/DeadlyAssaultPage.xaml.cs
+++ b/src/Starward/Features/GameRecord/ZZZ/DeadlyAssaultPage.xaml.cs
@@ -2,6 +2,7 @@ using CommunityToolkit.Mvvm.Input;
 using Microsoft.Extensions.Logging;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Media.Imaging;
 using Microsoft.UI.Xaml.Navigation;
 using Starward.Core;
 using Starward.Core.GameRecord;
@@ -150,6 +151,23 @@ public sealed partial class DeadlyAssaultPage : PageBase
         int d = value / 100;
         int p = value % 100;
         return $"{d}.{p:D2}%";
+    }
+
+
+    /// <summary>
+    /// 排名百分比背景图片，value 为以 0.01% 为单位的排名
+    /// </summary>
+    public static BitmapImage RankBackground(int value)
+    {
+        var img = value switch
+        {
+            <= 100 => "ms-appx:///Assets/Image/rank-bg-1.6a51d893.png",
+            <= 200 => "ms-appx:///Assets/Image/rank-bg-2.7522d7bb.png",
+            <= 500 => "ms-appx:///Assets/Image/rank-bg-3.370b7f26.png",
+            <= 3000 => "ms-appx:///Assets/Image/rank-bg-4.1b293bb1.png",
+            _ => "ms-appx:///Assets/Image/rank-bg-5.cf630a83.png",
+        };
+        return new BitmapImage(new Uri(img));
     }
 
 

--- a/src/Starward/Features/GameRecord/ZZZ/ShiyuDefensePage.xaml
+++ b/src/Starward/Features/GameRecord/ZZZ/ShiyuDefensePage.xaml
@@ -901,10 +901,19 @@
                                 <TextBlock FontSize="28"
                                            FontWeight="Bold"
                                            Text="{x:Bind CurrentShiyuDefenseV2.Brief.Score}" />
-                                <TextBlock Margin="0,0,0,6"
-                                           VerticalAlignment="Bottom"
-                                           Foreground="{ThemeResource TextFillColorSecondaryBrush}"
-                                           Text="{x:Bind local:ShiyuDefensePage.RankPercentText(CurrentShiyuDefenseV2.Brief.RankPercent)}" />
+                                <Grid Margin="0,0,0,6"
+                                      VerticalAlignment="Bottom">
+                                    <Image Height="20"
+                                           Stretch="Uniform"
+                                           Source="{x:Bind local:ShiyuDefensePage.RankBackground(CurrentShiyuDefenseV2.Brief.RankPercent)}" />
+                                    <TextBlock Margin="8,0,0,1"
+                                               HorizontalAlignment="Left"
+                                               VerticalAlignment="Center"
+                                               FontSize="14"
+                                               Foreground="Black"
+                                               FontWeight="Bold"
+                                               Text="{x:Bind local:ShiyuDefensePage.RankPercentText(CurrentShiyuDefenseV2.Brief.RankPercent)}" />
+                                </Grid>
                             </StackPanel>
                             <TextBlock FontSize="12"
                                        Foreground="{ThemeResource TextFillColorSecondaryBrush}"

--- a/src/Starward/Features/GameRecord/ZZZ/ShiyuDefensePage.xaml.cs
+++ b/src/Starward/Features/GameRecord/ZZZ/ShiyuDefensePage.xaml.cs
@@ -2,6 +2,7 @@ using CommunityToolkit.Mvvm.Input;
 using Microsoft.Extensions.Logging;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Media.Imaging;
 using Microsoft.UI.Xaml.Navigation;
 using Starward.Core;
 using Starward.Core.GameRecord;
@@ -190,6 +191,23 @@ public sealed partial class ShiyuDefensePage : PageBase
         int d = value / 100;
         int p = value % 100;
         return $"{d}.{p:D2}%";
+    }
+
+
+    /// <summary>
+    /// 排名百分比背景图片，value 为以 0.01% 为单位的排名
+    /// </summary>
+    public static BitmapImage RankBackground(int value)
+    {
+        var img = value switch
+        {
+            <= 100 => "ms-appx:///Assets/Image/rank-bg-1.6a51d893.png",
+            <= 200 => "ms-appx:///Assets/Image/rank-bg-2.7522d7bb.png",
+            <= 500 => "ms-appx:///Assets/Image/rank-bg-3.370b7f26.png",
+            <= 3000 => "ms-appx:///Assets/Image/rank-bg-4.1b293bb1.png",
+            _ => "ms-appx:///Assets/Image/rank-bg-5.cf630a83.png",
+        };
+        return new BitmapImage(new Uri(img));
     }
 
 


### PR DESCRIPTION
更新绝区零危局强袭战布局并新增绝境模式 #1906 #1907 
为危局强袭战和式舆防卫战排名百分比添加对应的背景图片
<img width="1782" height="1005" alt="image" src="https://github.com/user-attachments/assets/b9ea3b2b-26f0-4146-9c78-63c8a57abc98" />

Assets:
[star-icon-hard.13c9ee51.png](https://act.mihoyo.com/app/mihoyo-zzz-game-record/images/star-icon-hard.13c9ee51.png)
<img width="72" height="72" alt="star-icon-hard 13c9ee51" src="https://github.com/user-attachments/assets/4e727126-6831-4948-8a09-93d1d2f7350c" />
[rank-bg-1.6a51d893.png](https://act.mihoyo.com/app/mihoyo-zzz-game-record/images/rank-bg-1.6a51d893.png)
<img width="204" height="60" alt="rank-bg-1 6a51d893" src="https://github.com/user-attachments/assets/ed43ca4b-5993-4bae-ba35-f5b6f55f23e6" />
[rank-bg-2.7522d7bb.png](https://act.mihoyo.com/app/mihoyo-zzz-game-record/images/rank-bg-2.7522d7bb.png)
<img width="204" height="60" alt="rank-bg-2 7522d7bb" src="https://github.com/user-attachments/assets/315aa0f9-af50-408f-985b-498bb24a7f19" />
[rank-bg-3.370b7f26.png](https://act.mihoyo.com/app/mihoyo-zzz-game-record/images/rank-bg-3.370b7f26.png)
<img width="204" height="60" alt="rank-bg-3 370b7f26" src="https://github.com/user-attachments/assets/5a8bef0a-87b5-4ca7-b0e5-60c86084bab1" />
[rank-bg-4.1b293bb1.png](https://act.mihoyo.com/app/mihoyo-zzz-game-record/images/rank-bg-4.1b293bb1.png)
<img width="225" height="60" alt="rank-bg-4 1b293bb1" src="https://github.com/user-attachments/assets/0f547443-e524-4dce-b5f3-ed666efafc01" />
[rank-bg-5.cf630a83.png](https://act.mihoyo.com/app/mihoyo-zzz-game-record/images/rank-bg-5.cf630a83.png)
<img width="243" height="60" alt="rank-bg-5 cf630a83" src="https://github.com/user-attachments/assets/bad67cbb-6f57-489f-9aae-34c54e4ec8a1" />
