### PR TITLE
fix: "MaxWidth" should be changed to "Width".

### DIFF
--- a/src/Starward/Features/GameRecord/ZZZ/DeadlyAssaultPage.xaml
+++ b/src/Starward/Features/GameRecord/ZZZ/DeadlyAssaultPage.xaml
@@ -166,7 +166,7 @@
                 </Grid>
 
                 <!--  绝境模式  -->
-                <Grid MaxWidth="680"
+                <Grid Width="680"
                       Padding="16,12,16,12"
                       HorizontalAlignment="Center"
                       Background="{ThemeResource CustomOverlayAcrylicBrush}"
@@ -475,7 +475,7 @@
                 </Grid>
 
                 <!--  试炼模式  -->
-                <Grid MaxWidth="680"
+                <Grid Width="680"
                       Padding="16,12,16,12"
                       HorizontalAlignment="Center"
                       Background="{ThemeResource CustomOverlayAcrylicBrush}"


### PR DESCRIPTION
"MaxWidth"应改为"Width"，不然就会像这样没有节点数据时挤在一起
没什么影响，只是不太好看，应该没别的问题
#1908 时没注意，现在打不过发现了
<img width="1075" height="360" alt="image" src="https://github.com/user-attachments/assets/1f65dd18-3fc4-4ee4-8830-f199f2b13555" />
<img width="1085" height="314" alt="image" src="https://github.com/user-attachments/assets/df1f5546-b8b5-4725-9746-f3a5b3d5b5c9" />
`总得分&排名`与`挑战详情`不是同时刷新，间隔一小时左右，只会影响这一个小时内刷新查看