### PR TITLE
fix: 窗口激活时刷新账号列表，修复游戏内切换账号后保存旧数据的问题 Close #1920

### DIFF
--- a/src/Starward/Features/GameAccount/GameAccountSwitcher.xaml.cs
+++ b/src/Starward/Features/GameAccount/GameAccountSwitcher.xaml.cs
@@ -1,11 +1,13 @@
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
+using CommunityToolkit.Mvvm.Messaging;
 using Microsoft.Extensions.Logging;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Input;
 using Microsoft.UI.Xaml.Media;
 using Starward.Core;
+using Starward.Features.ViewHost;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -36,6 +38,7 @@ public sealed partial class GameAccountSwitcher : UserControl
     private void GameAccountSwitcher_Loaded(object sender, RoutedEventArgs e)
     {
         UpdateGameAccount();
+        WeakReferenceMessenger.Default.Register<MainWindowStateChangedMessage>(this, OnMainWindowActivated);
     }
 
 
@@ -44,12 +47,36 @@ public sealed partial class GameAccountSwitcher : UserControl
         SelectGameAccount = null;
         GameAccountList = null!;
         suggestionUids = null!;
+        WeakReferenceMessenger.Default.Unregister<MainWindowStateChangedMessage>(this);
     }
 
 
 
     public GameBiz CurrentGameBiz { get; set; }
 
+
+    private void OnMainWindowActivated(object _, MainWindowStateChangedMessage message)
+    {
+        if (message.Activate)
+        {
+            try
+            {
+                var regAccount = _gameAccountService.GetGameAccountFromRegistry(CurrentGameBiz);
+                // 只有注册表账号变了才刷新列表
+                if (regAccount is not null &&
+                    GameAccountList is not null &&
+                    GameAccountList.Count > 0 &&
+                    GameAccountList[0].SHA256 != regAccount.SHA256)
+                {
+                    UpdateGameAccount();
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Check registry account on window activated");
+            }
+        }
+    }
 
 
     public List<GameAccount> GameAccountList { get; set => SetProperty(ref field, value); }


### PR DESCRIPTION
关联 #1920

窗口激活时（用户从游戏 Alt-Tab 回 Starward），检查注册表账号是否变化，若变化则刷新列表。

选择"窗口激活"而非"游戏退出"作为刷新时机，原因：用户可能全程不关闭游戏，在游戏和启动器之间来回切换保存多个账号。

利用已有的 MainWindowStateChangedMessage { Activate = true } 消息（MainWindow 在 WM_ACTIVATE 时广播），无需新增消息类型。

逻辑说明

- 窗口激活时，读取注册表hash和列表第0项对比
- 相同：不刷新
- 不同： UpdateGameAccount 重建列表