### PR TITLE
fix: sync Genshin HDR toggle with the actual game registry state

### DIFF
--- a/src/Starward/Features/GameSetting/GameSettingPage.xaml.cs
+++ b/src/Starward/Features/GameSetting/GameSettingPage.xaml.cs
@@ -233,7 +233,7 @@ public sealed partial class GameSettingPage : PageBase
             {
                 IsGraphicsSettingEnable = true;
                 StackPanel_GenshinHDR.Visibility = Visibility.Visible;
-                EnableGenshinHDR = AppConfig.EnableGenshinHDR;
+                EnableGenshinHDR = GameSettingService.GetGenshinEnableHDR(CurrentGameBiz) ?? AppConfig.EnableGenshinHDR;
                 _displayInformation = DisplayInformation.CreateForWindowId(this.XamlRoot.GetAppWindow().Id);
                 _displayInformation.AdvancedColorInfoChanged += _displayInformation_AdvancedColorInfoChanged;
                 UpdateHdrState(_displayInformation);

--- a/src/Starward/Features/GameSetting/GameSettingService.cs
+++ b/src/Starward/Features/GameSetting/GameSettingService.cs
@@ -257,6 +257,23 @@ internal static class GameSettingService
 
 
 
+    public static bool? GetGenshinEnableHDR(GameBiz biz)
+    {
+        if (biz.Game is GameBiz.hk4e)
+        {
+            try
+            {
+                string key = biz.GetGameRegistryKey();
+                return Registry.GetValue(key, WINDOWS_HDR_ON_h3132281285, null) as int? is int v and not 0;
+            }
+            catch
+            {
+                return null;
+            }
+        }
+        return null;
+    }
+
 
 
     public static (int MaxLuminance, int SceneLuminance, int UILuminance) GetGenshinHDRLuminance(GameBiz biz)


### PR DESCRIPTION
## Summary

- The Genshin HDR switch in game settings was initialized from `AppConfig.EnableGenshinHDR` only, so it could disagree with the game's real setting after HDR was toggled in-game or written by another tool
- Add `GameSettingService.GetGenshinEnableHDR` reading the `WINDOWS_HDR_ON_h3132281285` registry value (hk4e only), the read-side counterpart of the existing `SetGenshinEnableHDR`
- The page now prefers the registry state and falls back to `AppConfig` when unavailable (non-hk4e, registry read failure, or value not present)

## Test plan

- [ ] Launch Genshin with HDR enabled in-game → the switch in Starward shows ON on page load
- [ ] Toggle HDR off in-game, reopen the game settings page → the switch shows OFF
- [ ] Non-Genshin games → switch still initializes from AppConfig as before