### PR TITLE
fix: pause dynamic video background when main window is minimized

### DIFF
--- a/src/Starward/Features/Background/AppBackground.xaml.cs
+++ b/src/Starward/Features/Background/AppBackground.xaml.cs
@@ -605,15 +605,14 @@ public sealed partial class AppBackground : UserControl
     {
         try
         {
-            // 各 suspend reason 由对应窗口信号独立维护：Hide/Activate → hidden、WM_SIZE → minimized、WTS lock/unlock → sessionLocked；
-            // 播放/暂停由聚合状态统一决定，任何单个恢复事件都不能越过其他暂停条件。
+            // 各暂停条件由对应窗口消息独立维护，播放或暂停由聚合状态统一决定
             if (message.Hide)
             {
                 _windowHidden = true;
             }
             if (message.Activate)
             {
-                // 窗口重新激活意味着已回到屏幕前，但不得影响 minimized/session 状态
+                // 激活只代表窗口回到屏幕前，不改变最小化和锁屏状态
                 _windowHidden = false;
             }
             if (message.Minimized is bool minimized)

--- a/src/Starward/Features/Background/AppBackground.xaml.cs
+++ b/src/Starward/Features/Background/AppBackground.xaml.cs
@@ -361,6 +361,14 @@ public sealed partial class AppBackground : UserControl
 
     private SemaphoreSlim _videoSemaphore = new SemaphoreSlim(1, 1);
 
+    private bool _windowHidden;
+
+    private bool _windowMinimized;
+
+    private bool _sessionLocked;
+
+    private bool ShouldPauseVideo => _windowHidden || _windowMinimized || _sessionLocked;
+
 
     private void StartMediaPlayer(string file)
     {
@@ -402,6 +410,11 @@ public sealed partial class AppBackground : UserControl
         _mediaPlayer.VideoFrameAvailable += MediaPlayer_VideoFrameAvailable;
         _mediaPlayer.MediaFailed += MediaPlayer_MediaFailed;
         _mediaPlayer.Play();
+        // 若窗口当前不处于可播放状态（最小化、隐藏或锁屏），暂停新建的播放器
+        if (ShouldPauseVideo)
+        {
+            _mediaPlayer.Pause();
+        }
     }
 
 
@@ -592,16 +605,38 @@ public sealed partial class AppBackground : UserControl
     {
         try
         {
+            // 各 suspend reason 由对应窗口信号独立维护：Hide/Activate → hidden、WM_SIZE → minimized、WTS lock/unlock → sessionLocked；
+            // 播放/暂停由聚合状态统一决定，任何单个恢复事件都不能越过其他暂停条件。
+            if (message.Hide)
+            {
+                _windowHidden = true;
+            }
+            if (message.Activate)
+            {
+                // 窗口重新激活意味着已回到屏幕前，但不得影响 minimized/session 状态
+                _windowHidden = false;
+            }
+            if (message.Minimized is bool minimized)
+            {
+                _windowMinimized = minimized;
+            }
+            if (message.SessionLock)
+            {
+                _sessionLocked = true;
+            }
+            if (message.SessionUnlock)
+            {
+                _sessionLocked = false;
+            }
             if (_mediaPlayer is not null)
             {
-                var state = _mediaPlayer.PlaybackSession.PlaybackState;
-                if (message.Activate && state is not MediaPlaybackState.Playing)
-                {
-                    _mediaPlayer.Play();
-                }
-                else if (message.Hide || message.SessionLock)
+                if (ShouldPauseVideo)
                 {
                     _mediaPlayer.Pause();
+                }
+                else if (_mediaPlayer.PlaybackSession.PlaybackState is not MediaPlaybackState.Playing)
+                {
+                    _mediaPlayer.Play();
                 }
             }
         }

--- a/src/Starward/Features/ViewHost/MainWindow.xaml.cs
+++ b/src/Starward/Features/ViewHost/MainWindow.xaml.cs
@@ -210,7 +210,7 @@ public sealed partial class MainWindow : WindowEx
         }
         else if (uMsg == (uint)User32.WindowMessage.WM_SIZE)
         {
-            // 窗口最小化 (SIZE_MINIMIZED) 或还原 (SIZE_RESTORED/SIZE_MAXIMIZED)，通知动态背景暂停或恢复
+            // 窗口最小化或还原，通知动态背景暂停或恢复
             if (wParam is 0 or 1 or 2)
             {
                 bool minimized = wParam is 1;

--- a/src/Starward/Features/ViewHost/MainWindow.xaml.cs
+++ b/src/Starward/Features/ViewHost/MainWindow.xaml.cs
@@ -178,6 +178,9 @@ public sealed partial class MainWindow : WindowEx
     private DateTimeOffset _lastActivatedTime = DateTimeOffset.Now;
 
 
+    private bool _isMinimized;
+
+
     protected override nint WindowSubclassProc(HWND hWnd, uint uMsg, nint wParam, nint lParam, nuint uIdSubclass, nint dwRefData)
     {
         if (uMsg == (uint)User32.WindowMessage.WM_ACTIVATE || uMsg == (uint)User32.WindowMessage.WM_POINTERACTIVATE)
@@ -205,6 +208,19 @@ public sealed partial class MainWindow : WindowEx
                 return IntPtr.Zero;
             }
         }
+        else if (uMsg == (uint)User32.WindowMessage.WM_SIZE)
+        {
+            // 窗口最小化 (SIZE_MINIMIZED) 或还原 (SIZE_RESTORED/SIZE_MAXIMIZED)，通知动态背景暂停或恢复
+            if (wParam is 0 or 1 or 2)
+            {
+                bool minimized = wParam is 1;
+                if (minimized != _isMinimized)
+                {
+                    _isMinimized = minimized;
+                    WeakReferenceMessenger.Default.Send(new MainWindowStateChangedMessage { Minimized = minimized, CurrentTime = DateTimeOffset.Now });
+                }
+            }
+        }
         else if (uMsg == (uint)User32.WindowMessage.WM_WTSSESSION_CHANGE)
         {
             if (wParam == 0x7)
@@ -215,7 +231,8 @@ public sealed partial class MainWindow : WindowEx
             }
             else if (wParam == 0x8)
             {
-                // WTS_SESSION_UNLOCK 
+                // WTS_SESSION_UNLOCK
+                WeakReferenceMessenger.Default.Send(new MainWindowStateChangedMessage { SessionUnlock = true, CurrentTime = DateTimeOffset.Now });
             }
         }
         else if (uMsg == (uint)User32.WindowMessage.WM_DEVICECHANGE)

--- a/src/Starward/Features/ViewHost/MainWindowStateChangedMessage.cs
+++ b/src/Starward/Features/ViewHost/MainWindowStateChangedMessage.cs
@@ -20,9 +20,6 @@ internal class MainWindowStateChangedMessage
     public bool SessionUnlock { get; set; }
 
 
-    /// <summary>
-    /// 主窗口是否进入或退出最小化状态；null 表示此消息与最小化无关
-    /// </summary>
     public bool? Minimized { get; set; }
 
 

--- a/src/Starward/Features/ViewHost/MainWindowStateChangedMessage.cs
+++ b/src/Starward/Features/ViewHost/MainWindowStateChangedMessage.cs
@@ -17,6 +17,15 @@ internal class MainWindowStateChangedMessage
     public bool SessionLock { get; set; }
 
 
+    public bool SessionUnlock { get; set; }
+
+
+    /// <summary>
+    /// 主窗口是否进入或退出最小化状态；null 表示此消息与最小化无关
+    /// </summary>
+    public bool? Minimized { get; set; }
+
+
     public DateTimeOffset CurrentTime { get; set; }
 
 


### PR DESCRIPTION
## 问题

主窗口最小化后，动态视频背景仍然持续播放和解码。

`MainWindow.WindowSubclassProc` 此前只处理了 `WM_ACTIVATE`、`WM_WTSSESSION_CHANGE`
等消息，没有处理 `WM_SIZE`。普通最小化（标题栏按钮、`ShowWindow(SW_MINIMIZE)`、
启动游戏时的最小化动作）不会产生任何 `MainWindowStateChangedMessage`，
`AppBackground` 无从得知窗口已最小化，`MediaPlayer` 继续解码。

实测：

| 状态 | 修复前 CPU |
| --- | --- |
| 前台播放 | ~105%（≈1 核） |
| 最小化 | ~105%（几乎不下降） |

另外，现有的恢复逻辑本质是 event-toggle：`Hide → Pause`、`SessionLock → Pause`、
`Activate → Play`。单个恢复事件会无条件覆盖其他暂停条件，例如
`最小化 → 锁屏 → 还原` 时 `WM_ACTIVATE` 会导致在锁屏期间错误恢复播放。

## 修改

不改动媒体管线（frame server / Win2D / 解码器均不动），只修窗口生命周期状态：

1. **`MainWindowStateChangedMessage`**   
   - 新增 `bool? Minimized`：`true` 进入最小化 / `false` 退出最小化 / `null` 与最小化无关
   - 新增 `bool SessionUnlock`：补上此前为空的 `WTS_SESSION_UNLOCK` 分支

3. **`MainWindow.xaml.cs`**
   - `WindowSubclassProc` 新增 `WM_SIZE` 分支：`SIZE_MINIMIZED` → `Minimized = true`，
     `SIZE_RESTORED / SIZE_MAXIMIZED` → `Minimized = false`（窗口本身
     `IsMaximizable = false`，MAXIMIZED 仅作防御）
   - 用 `_isMinimized` 去抖，仅在状态翻转时发消息，避免 `SIZE_RESTORED` 噪音
     （DPI 变化、移动窗口等）流入其他消息消费者
   - `WTS_SESSION_UNLOCK` 发送 `{ SessionUnlock = true }`

4. **`AppBackground.xaml.cs`**
   - 以三个私有字段聚合 suspend reason：`_windowHidden`、`_windowMinimized`、`_sessionLocked`
   - 每个状态只由各自对应的窗口信号维护：
     `Hide/Activate → hidden`、`WM_SIZE → minimized`、`WTS lock/unlock → sessionLocked`
   - `Activate` 只清除 hidden，不再无条件恢复播放；暂停/恢复统一由
     `ShouldPauseVideo = _windowHidden || _windowMinimized || _sessionLocked` 决策
   - `StartMediaPlayer` 末尾检查 `ShouldPauseVideo`：若窗口此刻不可播放
     （如最小化期间背景下载完成），新建的播放器立即暂停，
     避免错过已发生的状态消息

用户手动暂停（封面右上角按钮）走 `StopVideo → DisposeVideoResource`，
播放器被释放为 null，生命周期消息对 null 播放器无操作，因此
"手动暂停 → 最小化 → 还原" 仍保持静态背景，不会被生命周期恢复覆盖。

## 行为对照

| 场景 | 修复前 | 修复后 |
| --- | --- | --- |
| 最小化 | 继续播放 | 暂停 |
| 最小化 → 还原 | 继续播放 | 恢复播放 |
| 最小化 → 锁屏 → 还原（锁屏未解除） | **错误恢复播放** | 保持暂停 |
| 锁屏 → 解锁（窗口可见） | 保持暂停，需点击窗口恢复 | 解锁即恢复 |
| 锁屏 → 最小化 → 解锁（仍最小化） | 保持暂停 | 保持暂停 |
| ESC 隐藏 → 重新显示 | 暂停 → 恢复（不变） | 不变 |
| 手动暂停 → 最小化 → 还原 | 静态背景（不变） | 不变 |
| 最小化期间背景下载完成 | 最小化状态下开始播放 | 创建后立即暂停，还原后播放 |

## 验证

- `dotnet build src/Starward/Starward.csproj -c Debug -p:Platform=x64`：0 错误，
  触碰文件无新增警告
- 字段实测（Debug 构建，webm 动态封面，CPU 为单核百分比）：

| 场景 | CPU |
| --- | --- |
| 前台播放 | 90~118% |
| 最小化 10s | **2.0~2.9%** |
| 还原后 | 90~114% |
| ESC 隐藏 | 0.4~2.9% |

- 已确认消息的其他消费者（`GameBannerAndPost`、`GameLauncherPage`、
  `GameSelector`、`MainView`）语义不受影响

